### PR TITLE
Export the on-screen wireframe as a formatted PLOT3D surface file

### DIFF
--- a/src/fltk_screens/exportFileScreen.fl
+++ b/src/fltk_screens/exportFileScreen.fl
@@ -1,6 +1,6 @@
 # data file for the Fltk User Interface Designer (fluid)
-version 1.0300 
-header_name {.h} 
+version 1.0300
+header_name {.h}
 code_name {.cxx}
 class ExportFileUI {open
 } {
@@ -8,51 +8,55 @@ class ExportFileUI {open
   } {
     Fl_Window UIWindow {
       label {Export File} open
-      xywh {630 89 148 305} type Double color 29 resizable visible
+      xywh {630 89 148 335} type Double color 29 resizable visible
     } {
       Fl_Box {} {
         label Export
         xywh {5 5 136 16} box ROUNDED_BOX color 12 labelfont 1 labelsize 16 labelcolor 7
       }
-      Fl_Button sterolithButton {
-        label {Sterolith File (.stl)}
-        xywh {5 95 136 25} labelfont 1 labelsize 12 align 64
-      }
-      Fl_Button xsecButton {
-        label {XSec File (.hrm)}
-        xywh {5 65 136 25} labelfont 1 labelsize 12 align 64
-      }
-      Fl_Button nascartButton {
-        label {NASCART File (.dat)}
-        xywh {5 125 136 25} labelfont 1 labelsize 12 align 64
-      }
-      Fl_Button povrayButton {
-        label {POVRAY (.pov)}
-        xywh {5 215 136 25} labelfont 1 labelsize 12 align 64
-      }
-      Fl_Button cart3dButton {
-        label {CART3d File (.tri)}
-        xywh {5 155 136 25} labelfont 1 labelsize 12 align 64
-      }
-      Fl_Button gmshButton {
-        label {Gmsh File (.msh)}
-        xywh {5 185 136 25} labelfont 1 labelsize 12 align 64
-      }
-      Fl_Button x3dButton {
-        label {X3D (.x3d)}
-        xywh {5 245 136 25} labelfont 1 labelsize 12 align 64
-      }
-      Fl_Choice setChoice {open
-        xywh {5 40 136 20} down_box FLAT_BOX color 17 textfont 1
-      } {}
       Fl_Box {} {
         label Sets
         xywh {5 25 136 15} box BORDER_BOX labelfont 1 labelcolor 15
       }
+      Fl_Choice setChoice {open
+        xywh {5 40 136 20} down_box FLAT_BOX color 17 textfont 1
+      } {}
+      Fl_Button xsecButton {
+        label {XSec File (.hrm)}
+        xywh {5 65 136 25} labelfont 1 labelsize 12 align 64
+      }
+      Fl_Button plot3dButton {
+        label {PLOT3D File (.p3d)}
+        xywh {5 95 136 25} labelfont 1 labelsize 12 align 64
+      }
+      Fl_Button sterolithButton {
+        label {Sterolith File (.stl)}
+        xywh {5 125 136 25} labelfont 1 labelsize 12 align 64
+      }
+      Fl_Button nascartButton {
+        label {NASCART File (.dat)}
+        xywh {5 155 136 25} labelfont 1 labelsize 12 align 64
+      }
+      Fl_Button cart3dButton {
+        label {CART3d File (.tri)}
+        xywh {5 185 136 25} labelfont 1 labelsize 12 align 64
+      }
+      Fl_Button gmshButton {
+        label {Gmsh File (.msh)}
+        xywh {5 215 136 25} labelfont 1 labelsize 12 align 64
+      }
+      Fl_Button povrayButton {
+        label {POVRAY (.pov)}
+        xywh {5 245 136 25} labelfont 1 labelsize 12 align 64
+      }
+      Fl_Button x3dButton {
+        label {X3D (.x3d)}
+        xywh {5 275 136 25} labelfont 1 labelsize 12 align 64
+      }
       Fl_Button stepButton {
         label {STEP (.stp)}
-        xywh {5 275 136 25} labelfont 1 labelsize 12 align 64
+        xywh {5 305 136 25} labelfont 1 labelsize 12 align 64
       }
     }
   }
-} 
+}

--- a/src/geom_api/APIDefines.h
+++ b/src/geom_api/APIDefines.h
@@ -105,6 +105,7 @@ enum IMPORT_TYPE {  IMPORT_STL,
 
 enum EXPORT_TYPE {  EXPORT_FELISA,
                     EXPORT_XSEC,
+                    EXPORT_PLOT3D,
                     EXPORT_STL,
                     EXPORT_AWAVE,
                     EXPORT_NASCART,

--- a/src/geom_core/Geom.cpp
+++ b/src/geom_core/Geom.cpp
@@ -1630,6 +1630,58 @@ void Geom::WriteXSecFile( int geom_no, FILE* dump_file )
     }
 }
 
+void Geom::WritePLOT3DFileExtents( FILE* dump_file )
+{
+    for ( int i = 0 ; i < ( int )m_SurfVec.size() ; i++ )
+    {
+        //==== Tessellate Surface ====//
+        vector< vector< vec3d > > pnts;
+        vector< vector< vec3d > > norms;
+
+        UpdateTesselate( i, pnts, norms, false );
+	//==== Write surface boundary extents ====//
+	fprintf( dump_file, " %d %d %d\n", static_cast<int>( pnts[0].size() ), static_cast<int>( pnts.size() ), 1 );
+    }
+}
+
+void Geom::WritePLOT3DFileXYZ( FILE* dump_file )
+{
+    for ( int i = 0 ; i < ( int )m_SurfVec.size() ; i++ )
+    {
+        //==== Tessellate Surface ====//
+        vector< vector< vec3d > > pnts;
+        vector< vector< vec3d > > norms;
+
+        UpdateTesselate( i, pnts, norms, false );
+
+        //==== Write XSec Data ====//
+        for ( int j = 0 ; j < ( int )pnts.size() ; j++ )
+        {
+            for ( int k = 0 ; k < ( int )pnts[j].size() ; k++ )
+            {
+                fprintf( dump_file, "%25.17e ", pnts[j][k].x() );
+            }
+        }
+	fprintf( dump_file, "\n" );
+        for ( int j = 0 ; j < ( int )pnts.size() ; j++ )
+        {
+            for ( int k = 0 ; k < ( int )pnts[j].size() ; k++ )
+            {
+                fprintf( dump_file, "%25.17e ", pnts[j][k].y() );
+            }
+        }
+	fprintf( dump_file, "\n" );
+        for ( int j = 0 ; j < ( int )pnts.size() ; j++ )
+        {
+            for ( int k = 0 ; k < ( int )pnts[j].size() ; k++ )
+            {
+                fprintf( dump_file, "%25.17e ", pnts[j][k].z() );
+            }
+        }
+	fprintf( dump_file, "\n" );
+    }
+}
+
 void Geom::CreateGeomResults( Results* res )
 {
     res->Add( ResData( "Type", vsp::GEOM_XSECS ) );

--- a/src/geom_core/Geom.h
+++ b/src/geom_core/Geom.h
@@ -400,6 +400,8 @@ public:
     }
 
     virtual void WriteXSecFile( int geom_no, FILE* dump_file );
+    virtual void WritePLOT3DFileExtents( FILE* dump_file );
+    virtual void WritePLOT3DFileXYZ( FILE* dump_file );
     virtual void WriteStl( FILE* fid ) {};
     virtual void WriteX3D( xmlNodePtr node );
     virtual void WritePovRay( FILE* fid, int comp_num );

--- a/src/geom_core/ScriptMgr.cpp
+++ b/src/geom_core/ScriptMgr.cpp
@@ -610,6 +610,8 @@ void ScriptMgrSingleton::RegisterEnums( asIScriptEngine* se )
     assert( r >= 0 );
     r = se->RegisterEnumValue( "EXPORT_TYPE", "EXPORT_XSEC", EXPORT_XSEC );
     assert( r >= 0 );
+    r = se->RegisterEnumValue( "EXPORT_TYPE", "EXPORT_PLOT3D", EXPORT_PLOT3D );
+    assert( r >= 0 );
     r = se->RegisterEnumValue( "EXPORT_TYPE", "EXPORT_STL", EXPORT_STL );
     assert( r >= 0 );
     r = se->RegisterEnumValue( "EXPORT_TYPE", "EXPORT_AWAVE", EXPORT_AWAVE );
@@ -809,7 +811,7 @@ void ScriptMgrSingleton::RegisterEnums( asIScriptEngine* se )
     r = se->RegisterEnumValue( "ERROR_CODE", "VSP_INVALID_XSEC_ID", vsp::VSP_INVALID_XSEC_ID );
     assert( r >= 0 );
 
- 
+
 }
 
 //==== Vec3d Constructors ====//
@@ -1035,7 +1037,7 @@ void ScriptMgrSingleton::RegisterCustomGeomMgr( asIScriptEngine* se )
     assert( r );
 
     r = se->RegisterGlobalFunction(
-        "void SetupCustomDefaultSource( int type, int surf_index, double l1, double r1, double u1, double w1, double l2 = 0, double r2 = 0, double u2 = 0, double w2 = 0 )", 
+        "void SetupCustomDefaultSource( int type, int surf_index, double l1, double r1, double u1, double w1, double l2 = 0, double r2 = 0, double u2 = 0, double w2 = 0 )",
         asMETHOD( CustomGeomMgrSingleton, SetupCustomDefaultSource ), asCALL_THISCALL_ASGLOBAL, &CustomGeomMgr );
     assert( r >= 0 );
     r = se->RegisterGlobalFunction( "void ClearAllCustomDefaultSources()",
@@ -1183,7 +1185,7 @@ void ScriptMgrSingleton::RegisterAPI( asIScriptEngine* se )
     r = se->RegisterGlobalFunction( "void AddDefaultSources()", asFUNCTION( vsp::AddDefaultSources ), asCALL_CDECL );
     assert( r >= 0 );
     r = se->RegisterGlobalFunction(
-        "void AddCFDSource( int type, const string & in geom_id, int surf_index, double l1, double r1, double u1, double w1, double l2 = 0, double r2 = 0, double u2 = 0, double w2 = 0 )", 
+        "void AddCFDSource( int type, const string & in geom_id, int surf_index, double l1, double r1, double u1, double w1, double l2 = 0, double r2 = 0, double u2 = 0, double w2 = 0 )",
         asFUNCTION( vsp::AddCFDSource ), asCALL_CDECL );
     assert( r >= 0 );
 
@@ -1407,13 +1409,13 @@ void ScriptMgrSingleton::RegisterUtility( asIScriptEngine* se )
 {
     //==== Register Utility Functions ====//
     int r;
-    r = se->RegisterGlobalFunction( "void Print(const string & in data, bool new_line = true )", asMETHODPR( ScriptMgrSingleton, Print, (const string &, bool), void ), asCALL_THISCALL_ASGLOBAL, &ScriptMgr );  
+    r = se->RegisterGlobalFunction( "void Print(const string & in data, bool new_line = true )", asMETHODPR( ScriptMgrSingleton, Print, (const string &, bool), void ), asCALL_THISCALL_ASGLOBAL, &ScriptMgr );
     assert( r >= 0 );
-    r = se->RegisterGlobalFunction( "void Print(const vec3d & in data, bool new_line = true )", asMETHODPR( ScriptMgrSingleton, Print, (const vec3d &, bool), void ), asCALL_THISCALL_ASGLOBAL, &ScriptMgr );  
+    r = se->RegisterGlobalFunction( "void Print(const vec3d & in data, bool new_line = true )", asMETHODPR( ScriptMgrSingleton, Print, (const vec3d &, bool), void ), asCALL_THISCALL_ASGLOBAL, &ScriptMgr );
     assert( r >= 0 );
-    r = se->RegisterGlobalFunction( "void Print(double data, bool new_line = true )", asMETHODPR( ScriptMgrSingleton, Print, (double, bool), void ), asCALL_THISCALL_ASGLOBAL, &ScriptMgr );  
+    r = se->RegisterGlobalFunction( "void Print(double data, bool new_line = true )", asMETHODPR( ScriptMgrSingleton, Print, (double, bool), void ), asCALL_THISCALL_ASGLOBAL, &ScriptMgr );
     assert( r >= 0 );
-    r = se->RegisterGlobalFunction( "void Print(int data, bool new_line = true )", asMETHODPR( ScriptMgrSingleton, Print, (int, bool), void ), asCALL_THISCALL_ASGLOBAL, &ScriptMgr );  
+    r = se->RegisterGlobalFunction( "void Print(int data, bool new_line = true )", asMETHODPR( ScriptMgrSingleton, Print, (int, bool), void ), asCALL_THISCALL_ASGLOBAL, &ScriptMgr );
     assert( r >= 0 );
     r = se->RegisterGlobalFunction( "double Min( double x, double y)", asMETHOD( ScriptMgrSingleton, Min ), asCALL_THISCALL_ASGLOBAL, &ScriptMgr );
     assert( r >= 0 );

--- a/src/geom_core/Vehicle.cpp
+++ b/src/geom_core/Vehicle.cpp
@@ -90,7 +90,7 @@ void Vehicle::Init()
     ScriptMgr.Init();
     AdvLinkMgr.Init();
     CustomGeomMgr.ReadCustomScripts( this );
- 
+
     m_Name = "Vehicle";
 
     SetVSP3FileName( "Unnamed.vsp3" );
@@ -1396,6 +1396,47 @@ void Vehicle::WriteXSecFile( const string & file_name, int write_set )
     fclose( dump_file );
 }
 
+//==== Write Formatted PLOT3D File ====//
+void Vehicle::WritePLOT3DFile( const string & file_name, int write_set )
+{
+    vector< Geom* > geom_vec = FindGeomVec( GetGeomVec( false ) );
+
+    int geom_cnt = 0;
+    for ( int i = 0 ; i < ( int )geom_vec.size() ; i++ )
+    {
+        if( geom_vec[i]->GetSetFlag( write_set ) )
+        {
+            geom_cnt += geom_vec[i]->GetNumTotalSurfs();
+        }
+    }
+
+    //==== Open file ====//
+    FILE* dump_file = fopen( file_name.c_str(), "w" );
+
+    //==== Write total number of surfaces ===//
+    fprintf( dump_file, " %d\n", geom_cnt );
+
+    //==== Write surface boundary extents ====//
+    for ( int i = 0 ; i < ( int )geom_vec.size() ; i++ )
+    {
+        if ( geom_vec[i]->GetSetFlag( write_set ) )
+        {
+	    geom_vec[i]->WritePLOT3DFileExtents( dump_file );
+        }
+    }
+
+    //==== Write surface boundary points ====//
+    for ( int i = 0 ; i < ( int )geom_vec.size() ; i++ )
+    {
+        if ( geom_vec[i]->GetSetFlag( write_set ) )
+        {
+            geom_vec[i]->WritePLOT3DFileXYZ( dump_file );
+        }
+    }
+
+    fclose( dump_file );
+}
+
 //==== Check for an existing mesh in set ====//
 bool Vehicle::ExistMesh( int set )
 {
@@ -2601,6 +2642,10 @@ void Vehicle::ExportFile( const string & file_name, int write_set, int file_type
     if ( file_type == EXPORT_XSEC )
     {
         WriteXSecFile( file_name, write_set );
+    }
+    else if ( file_type == EXPORT_PLOT3D )
+    {
+        WritePLOT3DFile( file_name, write_set  );
     }
     else if ( file_type == EXPORT_STL )
     {

--- a/src/geom_core/Vehicle.h
+++ b/src/geom_core/Vehicle.h
@@ -180,6 +180,7 @@ public:
     void ExportFile( const string & file_name, int write_set, int file_type );
     bool WriteXMLFile( const string & file_name, int set );
     void WriteXSecFile( const string & file_name, int write_set );
+    void WritePLOT3DFile( const string & file_name, int write_set );
     void WriteSTLFile( const string & file_name, int write_set );
     void WriteTaggedMSSTLFile( const string & file_name, int write_set );
     void WriteTRIFile( const string & file_name, int write_set );

--- a/src/gui_and_draw/ExportScreen.cpp
+++ b/src/gui_and_draw/ExportScreen.cpp
@@ -84,6 +84,10 @@ void ExportScreen::ExportFile( string &newfile, int write_set, int type )
     {
         newfile = m_ScreenMgr->GetSelectFileScreen()->FileChooser( "Write XSec File?", "*.hrm" );
     }
+    else if ( type == EXPORT_PLOT3D )
+    {
+        newfile = m_ScreenMgr->GetSelectFileScreen()->FileChooser( "Write PLOT3D File?", "*.p3d" );
+    }
     else if ( type == EXPORT_STL )
     {
         if ( (( STLOptionsScreen* ) m_ScreenMgr->GetScreen( ScreenMgr::VSP_STL_OPTIONS_SCREEN ))->ShowSTLOptionsScreen() )
@@ -143,6 +147,10 @@ void ExportScreen::CallBack( Fl_Widget *w )
     if ( w ==   m_ExportFileUI->xsecButton )        // Export CrossSection File
     {
         ExportFile( newfile, m_SelectedSetIndex, EXPORT_XSEC );
+    }
+    else if ( w == m_ExportFileUI->plot3dButton )
+    {
+        ExportFile( newfile, m_SelectedSetIndex, EXPORT_PLOT3D );
     }
     else if ( w == m_ExportFileUI->sterolithButton )
     {


### PR DESCRIPTION
This allows OpenVSP to export the same data as the HRM file to a formatted PLOT3D file as well.  I'm not sure if I added the 'EXPORT_PLOT3D' enum in a place that won't break a bunch of scripts, so please review.