### PR TITLE
Force -fPIC when compiling libxml2 on Linux x64.  Needed to create _v…

### DIFF
--- a/Libraries/cmake/External_LibXml2.cmake
+++ b/Libraries/cmake/External_LibXml2.cmake
@@ -46,6 +46,7 @@ else()
 		--without-zlib
 		--without-lzma
 		--disable-shared
+		"CFLAGS=-g -fPIC"
   )
   set(libxml2_build_command "")
   set(libxml2_install_command "")


### PR DESCRIPTION
…sp.so.

This is an alternative to another PR currently open to fix building the python/swig shared library _vsp.so.  I don't know CMAKE that well, and perhaps there is a more "cmake" way of doing this, but it works to build _vsp.so on RHEL/CentOS 6 with  the included libxml2.