### PR TITLE
Force -fPIC when compiling libxml2 on Linux x64.  

### DIFF
--- a/Libraries/cmake/External_LibXml2.cmake
+++ b/Libraries/cmake/External_LibXml2.cmake
@@ -46,6 +46,7 @@ else()
 		--without-zlib
 		--without-lzma
 		--disable-shared
+		"CFLAGS=-g -fPIC"
   )
   set(libxml2_build_command "")
   set(libxml2_install_command "")


### PR DESCRIPTION
Let me know if there's a better place to put this.  I've tried a number of things inside of External_LibXML2.cmake but this is the only thing that I could do to get it to actually modify the Makefile in libxml2.  

This is needed in order to link libxml2 into _vsp.so from the python_api on CentOS/RHEL 6.8 x86_64.