### PR TITLE
Fix control derivate bug in vspaero

### DIFF
--- a/src/vsp_aero/solver/vspaero.C
+++ b/src/vsp_aero/solver/vspaero.C
@@ -1797,18 +1797,6 @@ void StabilityAndControlSolve(void)
                 VSP_VLM().RotationalRate_q() = RotationalRate_qList_[1];
                 VSP_VLM().RotationalRate_r() = RotationalRate_rList_[1];
                        
-                // Zero out all control surfaces
-         
-                for ( k = 1 ; k <= VSP_VLM().VSPGeom().NumberOfSurfaces() ; k++ ) {
-                   
-                   for ( p = 1 ; p <= VSP_VLM().VSPGeom().VSP_Surface(k).NumberOfControlSurfaces() ; p++ ) {
-         
-                      VSP_VLM().VSPGeom().VSP_Surface(k).ControlSurface(p).DeflectionAngle() = 0.;
-         
-                   }
-                   
-                }
-            
                 Case++;
                 
                 k = 1;
@@ -1883,6 +1871,18 @@ void StabilityAndControlSolve(void)
                 CMmForCase[Case] =  VSP_VLM().CMy();       
                 CMnForCase[Case] = -VSP_VLM().CMz();                        
          
+                // Zero out all control surfaces for the cases that follow
+
+                for ( k = 1 ; k <= VSP_VLM().VSPGeom().NumberOfSurfaces() ; k++ ) {
+
+                   for ( p = 1 ; p <= VSP_VLM().VSPGeom().VSP_Surface(k).NumberOfControlSurfaces() ; p++ ) {
+
+                      VSP_VLM().VSPGeom().VSP_Surface(k).ControlSurface(p).DeflectionAngle() = 0.;
+
+                   }
+
+                }
+
                 printf("\n");      
                
              }   


### PR DESCRIPTION
There is a bug in `vspaero.C:StabilityAndControlSolve`: when there are multiple stability cases (i.e. multiple Betas, AoAs or Machs), the control surfaces are not zeroed out between these cases. This pull request would fix it. Here is an excerpt from `xy.stab` with two control groups showing the problem:

```
FIRST ITERATION WITH AoA=0
AoA_                    0.0000000 deg                 
...
Case                   Delta    Units         CFx          CFy      ... 
...
Control_Group_1        +1.000 deg          0.0003789    0.0005965   ...
Control_Group_2        +1.000 deg          0.0003600   -0.0013204   ... 

SECOND ITERATION WITH AoA=1    
...
AoA_                    1.0000000 deg                 
...
Base_Aero              +0.000 n/a          0.0002217   -0.0013572   ... 
Control_Group_2        +1.000 deg          0.0002217   -0.0013572   ... 
```

The second iteration with alpha=1.0 will start with the `Control_Group_2` deflection set to +1.0 deg, and this will result in wrong values for `Base_Aero`. It will have the same valuas that `Control_Group_2` has in every following iteration.

This patch fixes the problem by zeroing out the control surface deflections not before computing the control derivates, but after it.
