### PR TITLE
Future proofing for Matplotlib 3.2

### DIFF
--- a/src/python_api/packages/openvsp/openvsp/parasite_drag.py
+++ b/src/python_api/packages/openvsp/openvsp/parasite_drag.py
@@ -106,8 +106,8 @@ class ParasiteDragResults:
 
         plt.xlabel(self.Vinf_Label[0])
         plt.ylabel('CD_0')
-        plt.xlim(xmin=0.0)
-        plt.ylim(ymin=0.0)
+        plt.xlim(left=0.0)
+        plt.ylim(bottom=0.0)
         plt.legend(leg_str)
         plt.show()
 


### PR DESCRIPTION
Ran 'test_degen_geom.py' (from OpenVSP/src/python_api/packages/openvsp/openvsp/tests/)

Warning (from warnings module):
  File "C:\Users\Tom\AppData\Local\Programs\Python\Python36-32\lib\site-packages\matplotlib\axes\_base.py", line 3215
    alternative='`left`', obj_type='argument')
MatplotlibDeprecationWarning: 
The `xmin` argument was deprecated in Matplotlib 3.0 and will be removed in 3.2. Use `left` instead.

Warning (from warnings module):
  File "C:\Users\Tom\AppData\Local\Programs\Python\Python36-32\lib\site-packages\matplotlib\axes\_base.py", line 3604
    alternative='`bottom`', obj_type='argument')
MatplotlibDeprecationWarning: 
The `ymin` argument was deprecated in Matplotlib 3.0 and will be removed in 3.2. Use `bottom` instead.

Proposed change prevents this