### PR TITLE
Change append '>>' to overwrite '>|' in postinst script

### DIFF
--- a/src/cmake/postinst
+++ b/src/cmake/postinst
@@ -8,7 +8,7 @@ ln -nsf /opt/OpenVSP/vspslicer /usr/local/bin/vspslicer;
 ln -nsf /opt/OpenVSP/vspviewer /usr/local/bin/vspviewer;
 echo "Setting up desktop entry ...";
 ln -nsf /opt/OpenVSP/vspIcon.png /usr/share/pixmaps/vspIcon.png
-cat >> /usr/share/applications/vsp.desktop <<EOL
+cat >| /usr/share/applications/vsp.desktop <<EOL
 [Desktop Entry]
 Type=Application
 Version=1.0


### PR DESCRIPTION
This fixes issue #136 caused due to appending to vsp.desktop file. The
issue only occurs if the user has a previous installation of vsp installed 
using a deb file.