### PR TITLE
Print search path when VSP{AERO, VIEWER, SLICER} not found

### DIFF
--- a/src/geom_core/Vehicle.cpp
+++ b/src/geom_core/Vehicle.cpp
@@ -446,15 +446,15 @@ void Vehicle::SetupPaths()
 
     if( !CheckForFile( m_ExePath, m_VSPAEROCmd ) )
     {
-        printf("VSPAERO solver not found.\n");
+		printf("VSPAERO solver not found in %s.\n", m_ExePath.c_str());
     }
     if( !CheckForFile( m_ExePath, m_VIEWERCmd ) )
     {
-        printf("VSPAERO viewer not found.\n");
+        printf("VSPAERO viewer not found in %s.\n", m_ExePath.c_str());
     }
     if ( !CheckForFile( m_ExePath, m_SLICERCmd ) )
     {
-        printf( "VSPAERO slicer not found.\n" );
+        printf( "VSPAERO slicer not found in %s.\n", m_ExePath.c_str());
     }
 
     m_CustomScriptDirs.push_back( string( "./CustomScripts/" ) );


### PR DESCRIPTION
Improves debugging when using API and message of "VSP* not found."
Example when using Python API, the search path for VSPAERO, VSPVIEWER,
and VSPSLICER are not intuitive.