### PR TITLE
add default /usr path for stepcode install dir

### DIFF
--- a/src/cmake/FindSTEPCODE.cmake
+++ b/src/cmake/FindSTEPCODE.cmake
@@ -2,6 +2,10 @@
 #
 #   TODO: Use find_path and find_library
 
+IF(NOT STEPCODE_INSTALL_DIR)
+    set( STEPCODE_INSTALL_DIR "/usr")
+ENDIF()
+
 IF(NOT WIN32)
     set( STEPCODE_LIBRARIES
     ${STEPCODE_INSTALL_DIR}/lib/libsdai_ap203.a


### PR DESCRIPTION
ideally should use find_path and find_library but this is a tmp fix in the meanwhile