### PR TITLE
add default /usr path for stepcode install dir

### DIFF
--- a/src/cmake/FindSTEPCODE.cmake
+++ b/src/cmake/FindSTEPCODE.cmake
@@ -2,6 +2,10 @@
 #
 #   TODO: Use find_path and find_library
 
+IF(NOT STEPCODE_INSTALL_DIR)
+    set( STEPCODE_INSTALL_DIR "/usr")
+ENDIF()
+
 IF(NOT WIN32)
     set( STEPCODE_LIBRARIES
     ${STEPCODE_INSTALL_DIR}/lib/libsdai_ap203.a


### PR DESCRIPTION
When trying to build OpenVSP with the `-DUSE_SYSTEM_STEPCODE` I receive the following error:
```
[ 30%] Building CXX object src/util/CMakeFiles/util.dir/CADutil.cpp.o
In file included from /home/acxz/vcs/git/github/acxz/pkgbuilds/openvsp/src/OpenVSP-OpenVSP_3.21.2/src/util/CADutil.cpp:10:
/home/acxz/vcs/git/github/acxz/pkgbuilds/openvsp/src/OpenVSP-OpenVSP_3.21.2/src/util/CADutil.h:20:10: fatal error: STEPfile.h: No such file or directory
   20 | #include <STEPfile.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```
even though I have a system level `stepcode` package installed.

The reason is that `FindSTEPCODE.cmake` is not properly fleshed out. Hence the existing todos for `find_path` and `find_library`. I did not have the time to properly use these cmake functions so FindSTEPCODE.cmake uses the `/usr` directory (where system level packages are installed) for the install dir. After this change OpenVSP uses the system level stepcode to build.
`usr/local` is another system level directory that is not factored in this fix, furthering detailing this as a non-ideal solution.

Basically, FindSTEPCODE does not work for `-DUSE_SYSTEM_STEPCODE` and this fix adds the ability for `FindSTEPCODE` to find stepcode that is installed under '/usr/local`. If a proper approach is taken using `find_path` and `find_library` then there will be no need for this PR.

In any case, I believe that any fix is some progress in the right direction, but I understand if you don't want to merge it in since it _is_ a temporary solution.
As it is now however, the `-DUSE_SYSTEM_STEPCODE` flag does not work.

> I'm not sure what problem it fixes,

I should have made an issue about this error, I apologize. Must have been feeling pretty lazy that day :)

> Fundamentally, when using built-in libraries, we do not want to install them to the 'normal' system paths. We should strive to stay in the build directory someplace instead of going out to /usr. The whole point of using the bundled libraries is that they aren't installed to the system.

This PR will not affect the installation of builtin libraries.

Created new PR as the branch to merge in has changed. (old PR: #158) 