### PR TITLE
corrected ds in VSP_Aero

### DIFF
--- a/src/vsp_aero/solver/Vortex.C
+++ b/src/vsp_aero/solver/Vortex.C
@@ -224,7 +224,7 @@ void VORTEX::Velocity(float xyz_1[3], float xyz_2[3], float xyz_p[3], float Mach
 
     /* get (ub,vb,wb) in rotated coordinate system */
 
-    ds = SQR(xs) + ( SQR(t) + SQR(beta_2) )*SQR(zobar);
+    ds = SQR(xs) + ( SQR(t) + beta_2 )*SQR(zobar);
 
     d1 = SQR(y1) + SQR(zobar);
 


### PR DESCRIPTION
Bug in VORTEX::Velocity.  beta_2 is already a squared value. [See equation 27 of the VORLAX paper](https://ntrs.nasa.gov/citations/19780008059)

In a simple test case this reduces the lift curve slope.
<img width="933" alt="Old_vsp" src="https://user-images.githubusercontent.com/7077520/101860948-d5b16900-3b23-11eb-93ee-ec0647cd2bd5.png">

<img width="933" alt="new_vsp" src="https://user-images.githubusercontent.com/7077520/101860959-dcd87700-3b23-11eb-9b44-629d9ebd04b0.png">



