### PR TITLE
fix #165

### DIFF
--- a/src/geom_core/AnalysisMgr.cpp
+++ b/src/geom_core/AnalysisMgr.cpp
@@ -2276,6 +2276,9 @@ string VSPAEROSweepAnalysis::Execute()
             VSPAEROMgr.m_NoiseUnits.Set( nvd->GetInt( 0 ) );
         }
 
+        //==== Compute Geometry ====//
+        VSPAEROMgr.ComputeGeometry();
+
         //==== Execute Analysis ====//
         resId = VSPAEROMgr.ComputeSolver(stdout);
 


### PR DESCRIPTION
ComputeGeometry failed, as no geometry was computed before.

So call ComputeGeometry before ComputeSolver.