### PR TITLE
fix #165 Trigger geometry computation in vspscript before analysis

### DIFF
--- a/examples/vspaero_ex/Swept_Wing_API/TR1208.vspscript
+++ b/examples/vspaero_ex/Swept_Wing_API/TR1208.vspscript
@@ -66,6 +66,11 @@ void main()
   array<int> AlphaNpts(1, nAlpha);
   SetIntAnalysisInput(myAnalysis, "AlphaNpts", AlphaNpts);
 
+  // Run CompGeom to generate geometry
+  string compGeom = "VSPAEROComputeGeometry";
+  SetAnalysisInputDefaults(compGeom);
+  string compGeom_results = ExecAnalysis(compGeom);
+
   // Run analysis and write results to CSV file
   string allResults = ExecAnalysis(myAnalysis);
   WriteResultsCSVFile(allResults, "Results.csv");


### PR DESCRIPTION
ComputeGeometry failed, as no geometry was computed before.

See discussion in issue #165. @cibinjoseph proposed an alternative solution to pull request #166, which becomes obsolete.