### PR TITLE
Added surface tags to the cfd_mesh poly data (TetGen) output

### DIFF
--- a/src/cfd_mesh/CfdMeshMgr.cpp
+++ b/src/cfd_mesh/CfdMeshMgr.cpp
@@ -1083,7 +1083,8 @@ void CfdMeshMgrSingleton::WriteTetGen( const string &filename )
 
     //==== Write Tris ====//
     fprintf( fp, "# Part 2 - facet list\n" );
-    fprintf( fp, "%d 0\n", tri_cnt );
+    // <# of facets> <boundary markers (0 or 1)> 
+    fprintf( fp, "%d 1\n", tri_cnt );
 
     for ( int i = 0 ; i < ( int )m_SurfVec.size() ; i++ )
     {
@@ -1097,8 +1098,11 @@ void CfdMeshMgrSingleton::WriteTetGen( const string &filename )
             int ind1 = pntShift[i0] + 1;
             int ind2 = pntShift[i1] + 1;
             int ind3 = pntShift[i2] + 1;
+            int tag = SubSurfaceMgr.GetTag( sTriVec[t].m_Tags );
 
-            fprintf( fp, "1\n" );
+	    // <# of polygons> [# of holes] [boundary marker] 
+            fprintf( fp, "1 0 %d\n", tag );
+	    // <# of corners> <corner 1> <corner 2> <corner 3>
             fprintf( fp, "3 %d %d %d\n", ind1, ind2, ind3 );
         }
     }


### PR DESCRIPTION
I'm attempting to help a student group setup an open-source MDO workflow with CFD, starting with OpenVSP, creating a volume grid with TetGen, then pass that onto CFD. The current .poly (TetGen) output from OpenVSP doesn't support added the surface tags, which is needed to set boundary conditions. I've modified the function that write the TetGen file to include the boundary tags.
 
I can't think of a reason to not always include the tags, so I haven't added any optional controls. There is the possibility that this breaks someone's work flow, but I think tags should make using TetGen more accessible.