### PR TITLE
Vspaero output precision

### DIFF
--- a/src/geom_core/AnalysisMgr.cpp
+++ b/src/geom_core/AnalysisMgr.cpp
@@ -1374,7 +1374,7 @@ string VSPAEROSinglePointAnalysis::Execute()
         nvd = m_Inputs.FindPtr( "AnalysisMethod", 0 );
         VSPAEROMgr.m_AnalysisMethod.Set( nvd->GetInt( 0 ) );
 
-        //    Regerence area, length parameters
+        //    Reference area, length parameters
         int refFlagOrig    = VSPAEROMgr.m_RefFlag.Get();
         string WingIDOrig    = VSPAEROMgr.m_RefGeomID;
         double srefOrig    = VSPAEROMgr.m_Sref.Get();
@@ -1727,7 +1727,7 @@ string VSPAEROSinglePointAnalysis::Execute()
         VSPAEROMgr.m_GeomSet.Set( geomSetOrig );
         VSPAEROMgr.m_AnalysisMethod.Set( analysisMethodOrig );
 
-        //    Regerence area, length parameters
+        //    Reference area, length parameters
         VSPAEROMgr.m_RefFlag.Set( refFlagOrig );
         VSPAEROMgr.m_RefGeomID = WingIDOrig;
         VSPAEROMgr.m_Sref.Set( srefOrig );

--- a/src/geom_core/Geom.cpp
+++ b/src/geom_core/Geom.cpp
@@ -1124,6 +1124,13 @@ void Geom::Update( bool fullupdate )
         UpdateFlags();  // Needs to be after m_MainSurfVec is populated, but before m_SurfVec
     }
 
+    // Sets cluster parameters on m_MainSurfVec[0] for wings etc.
+    // Needs to be before m_MainSurfVec is copied to m_SurfVec.
+    if ( m_SurfDirty || m_TessDirty )
+    {
+        UpdatePreTess();
+    }
+
     if ( m_XFormDirty || m_SurfDirty )
     {
         UpdateSymmAttach();  // Needs to happen for both XForm and Surf updates.
@@ -1151,7 +1158,6 @@ void Geom::Update( bool fullupdate )
     // Tessellate MainSurfVec
     if ( m_SurfDirty || m_TessDirty )
     {
-        UpdatePreTess();
         UpdateMainTessVec();
         UpdateMainDegenGeomPreview();
     }

--- a/src/geom_core/VSPAEROMgr.cpp
+++ b/src/geom_core/VSPAEROMgr.cpp
@@ -1668,7 +1668,7 @@ Optional input of logFile allows outputting to a log file or the console
 string VSPAEROMgrSingleton::ComputeSolver( FILE * logFile )
 {
     Update(); // Force update to ensure correct number of unstead groups, actuator disks, etc when run though the API.
-    UpdateFilenames();
+    UpdateFilenames(); // Do we really need this? is also called by Update() moments before
 
     if ( m_DegenGeomVec.size() == 0 )
     {
@@ -2306,10 +2306,10 @@ int VSPAEROMgrSingleton::WaitForFile( string filename )
     // Wait until the results show up on the file system
     int n_wait = 0;
     // wait no more than 5 seconds = (50*100)/1000
-    while ( ( !FileExist( filename ) ) & ( n_wait < 50 ) )
+    while ( ( !FileExist( filename ) ) & ( n_wait < 100 ) )
     {
         n_wait++;
-        SleepForMilliseconds( 100 );
+        SleepForMilliseconds( 50 );
     }
     SleepForMilliseconds( 100 );  //additional wait for file
 

--- a/src/geom_core/Vehicle.cpp
+++ b/src/geom_core/Vehicle.cpp
@@ -4647,6 +4647,7 @@ string Vehicle::ImportFile( const string & file_name, int file_type )
             else
             {
                 SetActiveGeom( id );
+                new_geom->m_SurfDirty = true;
                 new_geom->Update();
             }
         }
@@ -4680,6 +4681,7 @@ string Vehicle::ImportFile( const string & file_name, int file_type )
                 else
                 {
                     SetActiveGeom( id );
+                    prop->m_SurfDirty = true;
                     prop->Update();
                 }
             }
@@ -4741,6 +4743,7 @@ string Vehicle::ImportFile( const string & file_name, int file_type )
             if ( new_geom )
             {
                 new_geom->ReadXSec( fp );
+                new_geom->m_SurfDirty = true;
             }
         }
         fclose( fp );
@@ -4805,6 +4808,7 @@ string Vehicle::ImportFile( const string & file_name, int file_type )
             if ( new_geom )
             {
                 new_geom->ReadP3D( fp, ni[c], nj[c], nk[c] );
+                new_geom->m_SurfDirty = true;
             }
         }
         fclose( fp );
@@ -4853,6 +4857,7 @@ string Vehicle::ImportFile( const string & file_name, int file_type )
             else
             {
                 SetActiveGeom( id );
+                new_geom->m_SurfDirty = true;
                 new_geom->Update();
             }
         }
@@ -4994,6 +4999,7 @@ string Vehicle::ImportV2File( const string & file_name )
                 {
                     add_geoms.push_back( id );
                     geom->ReadV2File( comp_node );
+                    geom->m_SurfDirty = true;
 
                     if ( geom->GetParentID().compare( "NONE" ) == 0 )
                     {

--- a/src/vsp_aero/solver/VSP_Solver.C
+++ b/src/vsp_aero/solver/VSP_Solver.C
@@ -2855,8 +2855,8 @@ void VSP_SOLVER::Solve(int Case)
     
     if ( !TimeAccurate_ ) {
 
-                          //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789          
-       fprintf(StatusFile_,"  Iter      Mach       AoA      Beta       CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz       T/QS \n");
+                          //123456789 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123          
+       fprintf(StatusFile_,"  Iter         Mach           AoA          Beta            CL           CDo           CDi         CDtot            CS           L/D             E           CFx           CFy           CFz           CMx           CMy           CMz          T/QS \n");
    
     }
     
@@ -2864,22 +2864,22 @@ void VSP_SOLVER::Solve(int Case)
        
        if ( TimeAnalysisType_ == HEAVE_ANALYSIS ) {
                  
-                             //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789     
-          fprintf(StatusFile_,"  Time      Mach       AoA      Beta       CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz       T/QS      H       CL_Un     CDi_Un    CS_Un     CFx_Un     CFy_Un    CFz_Un   CMx_Un    CMy_Un    CMz_Un \n");
+                             //1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123     
+          fprintf(StatusFile_,"     Time          Mach           AoA          Beta            CL           CDo           CDi         CDtot            CS           L/D             E           CFx            CFy          CFz           CMx           CMy           CMz          T/QS             H         CL_Un        CDi_Un         CS_Un        CFx_Un        CFy_Un        CFz_Un        CMx_Un        CMy_Un        CMz_Un \n");
 
        }
        
        else if ( TimeAnalysisType_ == P_ANALYSIS || TimeAnalysisType_ == Q_ANALYSIS ||  TimeAnalysisType_ == R_ANALYSIS ) {
          
-                             //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789          
-          fprintf(StatusFile_,"  Time      Mach       AoA      Beta       CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz       T/QS  UnstdyAng   CL_Un     CDi_Un    CS_Un     CFx_Un     CFy_Un    CFz_Un   CMx_Un    CMy_Un    CMz_Un \n");
+                             //1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123          
+          fprintf(StatusFile_,"     Time          Mach           AoA          Beta            CL           CDo           CDi         CDtot            CS           L/D             E           CFx            CFy          CFz           CMx           CMy           CMz          T/QS      UnstdyAng        CL_Un        CDi_Un         CS_Un        CFx_Un        CFy_Un        CFz_Un        CMx_Un        CMy_Un        CMz_Un \n");
 
        }
        
        else {
 
-                             //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789
-          fprintf(StatusFile_,"  Time      Mach       AoA      Beta       CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz       T/QS    CL_Un     CDi_Un    CS_Un     CFx_Un     CFy_Un    CFz_Un   CMx_Un    CMy_Un    CMz_Un \n");
+                             //1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123
+          fprintf(StatusFile_,"     Time          Mach           AoA          Beta            CL           CDo           CDi         CDtot            CS           L/D             E           CFx            CFy          CFz           CMx           CMy           CMz          T/QS         CL_Un        CDi_Un         CS_Un        CFx_Un        CFy_Un        CFz_Un        CMx_Un        CMy_Un        CMz_Un  \n");
       
        }
    
@@ -10305,8 +10305,8 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
     
     // Write out column labels
     
-                    // 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 
-    fprintf(LoadFile_,"   Wing       S        Yavg     Chord     V/Vref      Cl        Cd        Cs        Cx        Cy       Cz        Cmx       Cmy       Cmz \n");
+                    // 123456789 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 
+    fprintf(LoadFile_,"   Wing           S          Yavg         Chord        V/Vref            Cl            Cd            Cs            Cx            Cy            Cz           Cmx           Cmy           Cmz \n");
 
     TotalLift = 0.;  
 
@@ -10318,7 +10318,7 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
               
           for ( k = 1 ; k <= NumberOfStations ; k++ ) {
 
-             fprintf(LoadFile_,"%9d %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf \n",
+             fprintf(LoadFile_,"%9d % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E \n",
                      i,
                      VSPGeom().VSP_Surface(i).s(k),                    
                      Span_Yavg_[i][k],
@@ -10344,8 +10344,8 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
     
     fprintf(LoadFile_,"\n\n\n");
 
-                    // 123456789 123456789012345678901234567890123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789   
-    fprintf(LoadFile_,"Comp      Component-Name                             Mach       AoA      Beta       CL        CDi       CS       CFx       CFy       CFz       Cmx       Cmy       Cmz \n");
+                    // 1234567890123 123456789012345678901234567890123456789 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123   
+    fprintf(LoadFile_,"Comp          Component-Name                               Mach           AoA          Beta            CL           CDi            CS           CFx           CFy           CFz           Cmx           Cmy           Cmz \n");
 
     for ( i = 1 ; i <= VSPGeom().NumberOfSurfaces() ; i++ ) { 
      
@@ -10381,7 +10381,7 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
           CMy /= 0.5*Sref_*Cref_;
           CMz /= 0.5*Sref_*Bref_;
           
-          fprintf(LoadFile_,"%-9d %-40s %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf \n",
+          fprintf(LoadFile_,"%-9d %-40s % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E \n",
                   i,
                   VSPGeom().VSP_Surface(i).ComponentName(),
                   Mach_,
@@ -10403,7 +10403,7 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
         
           k = 1;
     
-          fprintf(LoadFile_,"%-9d %-40s %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf \n",
+          fprintf(LoadFile_,"%-9d %-40s % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E \n",
                   i,
                   VSPGeom().VSP_Surface(i).ComponentName(),
                   Mach_,
@@ -15230,7 +15230,7 @@ void VSP_SOLVER::OutputStatusFile(void)
 
     if ( !TimeAccurate_ ) {
        
-       fprintf(StatusFile_,"%9d %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",
+       fprintf(StatusFile_, "%9d % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",
                i,
                Mach_,
                AngleOfAttack_/TORAD,
@@ -15266,7 +15266,7 @@ void VSP_SOLVER::OutputStatusFile(void)
 
        if ( TimeAnalysisType_ == HEAVE_ANALYSIS ) {
           
-          fprintf(StatusFile_,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",
+            fprintf(StatusFile_, "% 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",
                   CurrentTime_,
                   Mach_,
                   AngleOfAttack_/TORAD,
@@ -15300,7 +15300,7 @@ void VSP_SOLVER::OutputStatusFile(void)
        
        else if ( TimeAnalysisType_ == P_ANALYSIS || TimeAnalysisType_ == Q_ANALYSIS || TimeAnalysisType_ == R_ANALYSIS ) {
           
-          fprintf(StatusFile_,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",
+            fprintf(StatusFile_, "% 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",
                   CurrentTime_,
                   Mach_,
                   AngleOfAttack_/TORAD,
@@ -15338,7 +15338,7 @@ void VSP_SOLVER::OutputStatusFile(void)
           
           if ( NoiseAnalysis_ ) Time = CurrentNoiseTime_;
           
-          fprintf(StatusFile_,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",
+          fprintf(StatusFile_, "% 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",
                   Time,
                   Mach_,
                   AngleOfAttack_/TORAD,

--- a/src/vsp_aero/solver/vspaero.C
+++ b/src/vsp_aero/solver/vspaero.C
@@ -2137,8 +2137,8 @@ void Solve(void)
 
     }    
 
-                     //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789   
-    fprintf(PolarFile,"  Beta      Mach       AoA      Re/1e6     CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz       CMl       CMm       CMn \n");
+                     //1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123
+    fprintf(PolarFile,"     Beta          Mach           AoA        Re/1e6            CL           CDo           CDi         CDtot            CS           L/D             E           CFx           CFy           CFz           CMx           CMy           CMz           CMl           CMm           CMn \n");
 
     // Write out polars, not these are written out in a different order than they were calculated above - we group them by Re number
     
@@ -2156,7 +2156,7 @@ void Solve(void)
    
                 E = ( CLForCase[Case] *CLForCase[Case] / ( PI * AR) ) / CDForCase[Case];
                 
-                fprintf(PolarFile,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf \n",             
+                fprintf(PolarFile,"% 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E \n",
                         BetaList_[i],
                         MachList_[j],
                         AoAList_[k],


### PR DESCRIPTION
Changes the output format for some VSPAERO output files to scientific notation.
This improves the performance of VSPAERO when used with optimization frameworks, as these output files contain the values the API returns. When the optimizer tries to obtain gradients by modifying parameters slightly, it may fail to capture the effects due to the low numerical precision of the output files.