### PR TITLE
Create /usr/local/bin if it does not exist

### DIFF
--- a/src/cmake/postinst
+++ b/src/cmake/postinst
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e;
 echo "Setting up symlinks ...";
+mkdir -p /usr/local/bin;
 ln -nsf /opt/OpenVSP/vsp /usr/local/bin/vsp;
 ln -nsf /opt/OpenVSP/vspaero /usr/local/bin/vspaero;
 ln -nsf /opt/OpenVSP/vspscript /usr/local/bin/vspscript;


### PR DESCRIPTION
In the rare instances that /usr/local/bin does not exist, it should be created explicitly by the post-installation script. 
This directory is where the soft links to vsp executables are created for user access.

This pull request avoids issues like #185 in future.