### PR TITLE
improvement of VSPAERO output precision based on 3.25.0

### DIFF
--- a/src/geom_core/AnalysisMgr.cpp
+++ b/src/geom_core/AnalysisMgr.cpp
@@ -1414,7 +1414,7 @@ string VSPAEROSinglePointAnalysis::Execute()
         nvd = m_Inputs.FindPtr( "AnalysisMethod", 0 );
         VSPAEROMgr.m_AnalysisMethod.Set( nvd->GetInt( 0 ) );
 
-        //    Regerence area, length parameters
+        //    Reference area, length parameters
         int refFlagOrig     = VSPAEROMgr.m_RefFlag.Get();
         string WingIDOrig   = VSPAEROMgr.m_RefGeomID;
         double srefOrig     = VSPAEROMgr.m_Sref.Get();
@@ -1785,7 +1785,7 @@ string VSPAEROSinglePointAnalysis::Execute()
         VSPAEROMgr.m_GeomSet.Set( geomSetOrig );
         VSPAEROMgr.m_AnalysisMethod.Set( analysisMethodOrig );
 
-        //    Regerence area, length parameters
+        //    Reference area, length parameters
         VSPAEROMgr.m_RefFlag.Set( refFlagOrig );
         VSPAEROMgr.m_RefGeomID = WingIDOrig;
         VSPAEROMgr.m_Sref.Set( srefOrig );

--- a/src/geom_core/VSPAEROMgr.cpp
+++ b/src/geom_core/VSPAEROMgr.cpp
@@ -1802,7 +1802,7 @@ Optional input of logFile allows outputting to a log file or the console
 string VSPAEROMgrSingleton::ComputeSolver( FILE * logFile )
 {
     Update(); // Force update to ensure correct number of unstead groups, actuator disks, etc when run though the API.
-    UpdateFilenames();
+    UpdateFilenames(); // Do we really need this? is also called by Update() moments before
 
     if ( m_DegenGeomVec.size() == 0 )
     {
@@ -2455,10 +2455,10 @@ int VSPAEROMgrSingleton::WaitForFile( string filename )
     // Wait until the results show up on the file system
     int n_wait = 0;
     // wait no more than 5 seconds = (50*100)/1000
-    while ( ( !FileExist( filename ) ) & ( n_wait < 50 ) )
+    while ( ( !FileExist( filename ) ) & ( n_wait < 100 ) )
     {
         n_wait++;
-        SleepForMilliseconds( 100 );
+        SleepForMilliseconds( 50 );
     }
     SleepForMilliseconds( 100 );  //additional wait for file
 

--- a/src/vsp_aero/solver/VSP_Solver.C
+++ b/src/vsp_aero/solver/VSP_Solver.C
@@ -3717,8 +3717,8 @@ void VSP_SOLVER::Solve(int Case)
     
     if ( !TimeAccurate_ ) {
 
-                          //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789          
-       FPRINTF(StatusFile_,"  Iter      Mach       AoA      Beta       CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz   CDtrefftz     T/QS \n");
+                          //123456789 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123          
+       FPRINTF(StatusFile_,"  Iter         Mach           AoA          Beta            CL           CDo           CDi         CDtot            CS           L/D             E           CFx           CFy           CFz           CMx           CMy           CMz       CDtrefftz      T/QS \n");
    
     }
     
@@ -3726,22 +3726,22 @@ void VSP_SOLVER::Solve(int Case)
        
        if ( TimeAnalysisType_ == HEAVE_ANALYSIS ) {
                  
-                             //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789  
-          FPRINTF(StatusFile_,"  Time      Mach       AoA      Beta       CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz   CDtrefftz     T/QS      H   \n");
+                             //1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123    
+          FPRINTF(StatusFile_,"     Time          Mach           AoA          Beta            CL           CDo           CDi         CDtot            CS           L/D             E           CFx            CFy          CFz           CMx           CMy           CMz       CDtrefftz      T/QS             H    \n");
 
        }
        
        else if ( TimeAnalysisType_ == P_ANALYSIS || TimeAnalysisType_ == Q_ANALYSIS ||  TimeAnalysisType_ == R_ANALYSIS ) {
          
-                             //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789        
-          FPRINTF(StatusFile_,"  Time      Mach       AoA      Beta       CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz   CDtrefftz     T/QS  UnstdyAng  \n");
+                             //1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123
+          FPRINTF(StatusFile_,"     Time          Mach           AoA          Beta            CL           CDo           CDi         CDtot            CS           L/D             E           CFx            CFy          CFz           CMx           CMy           CMz       CDtrefftz       T/QS        UnstdyAng  \n");
 
        }
        
        else {
 
-                             //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 
-          FPRINTF(StatusFile_,"  Time      Mach       AoA      Beta       CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz   CDtrefftz     T/QS  \n");
+                             //1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123
+          FPRINTF(StatusFile_,"     Time          Mach           AoA          Beta            CL           CDo           CDi         CDtot            CS           L/D             E           CFx            CFy          CFz           CMx           CMy           CMz       CDtrefftz       T/QS\n");
       
        }
    
@@ -13242,8 +13242,8 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
     
     // Write out column labels
     
-                    // 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 
-    FPRINTF(LoadFile_,"   Wing       S        Xavg      Yavg      Zavg     Chord     V/Vref      Cl        Cd        Cs        Cx        Cy       Cz        Cmx       Cmy       Cmz \n");
+                    // 123456789 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 
+    FPRINTF(LoadFile_, "   Wing       S            Xavg          Yavg           Zavg          Chord        V/Vref          Cl            Cd            Cs            Cx            Cy           Cz            Cmx           Cmy           Cmz \n");
 
     TotalLift = 0.;  
 
@@ -13275,7 +13275,7 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
         
           for ( k = 1 ; k <= NumberOfStations ; k++ ) {
 
-             FPRINTF(LoadFile_,"%9d %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf \n",
+              FPRINTF(LoadFile_, "%9d % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E \n",
                      i,
                      SpanLoadData(i).Span_S(k),                    
                      SpanLoadData(i).Span_Xavg(k),
@@ -13304,8 +13304,8 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
     
     FPRINTF(LoadFile_,"\n\n\n");
 
-                    // 123456789 123456789012345678901234567890123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789   
-    FPRINTF(LoadFile_,"Comp      Component-Name                             Mach       AoA      Beta       CL        CDi       CS       CFx       CFy       CFz       Cmx       Cmy       Cmz \n");
+                    // 1234567890123 123456789012345678901234567890123456789 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123   
+    FPRINTF(LoadFile_, "Comp         Component-Name                             Mach           AoA          Beta            CL             CDi           CS            CFx           CFy           CFz         Cmx           Cmy           Cmz \n");
 
     for ( i = StartOfSpanLoadDataSets_ ; i <= NumberOfSpanLoadDataSets_ ; i++ ) { 
           
@@ -13364,7 +13364,7 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
              
           }
            
-          FPRINTF(LoadFile_,"%-9d %-40s %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf \n",
+          FPRINTF(LoadFile_, "%-9d %-40s % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E \n",
                   i,
                   DumChar,
                   Mach_,
@@ -13408,7 +13408,7 @@ void VSP_SOLVER::CalculateSpanWiseLoading(void)
              
           }
 
-          FPRINTF(LoadFile_,"%-9d %-40s %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf \n",
+          FPRINTF(LoadFile_,"%-9d %-40s % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E \n",
                   i,
                   DumChar,
                   Mach_,
@@ -18257,7 +18257,7 @@ void VSP_SOLVER::OutputStatusFile(int Case)
 
     if ( !TimeAccurate_ ) {
        
-       FPRINTF(StatusFile_,"%9d %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",
+        FPRINTF(StatusFile_, "%9d % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",
                i,
                Mach_,
                FLOAT(AngleOfAttack_/TORAD),
@@ -18315,7 +18315,7 @@ void VSP_SOLVER::OutputStatusFile(int Case)
 
        if ( TimeAnalysisType_ == HEAVE_ANALYSIS ) {
           
-          FPRINTF(StatusFile_,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",
+           FPRINTF(StatusFile_, "% 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",
                   CurrentTime_,
                   Mach_,
                   FLOAT(AngleOfAttack_/TORAD),
@@ -18341,7 +18341,7 @@ void VSP_SOLVER::OutputStatusFile(int Case)
        
        else if ( TimeAnalysisType_ == P_ANALYSIS || TimeAnalysisType_ == Q_ANALYSIS || TimeAnalysisType_ == R_ANALYSIS ) {
           
-          FPRINTF(StatusFile_,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",
+            FPRINTF(StatusFile_, "%9.5lf % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",
                   CurrentTime_,
                   Mach_,
                   FLOAT(AngleOfAttack_/TORAD),
@@ -18375,7 +18375,7 @@ void VSP_SOLVER::OutputStatusFile(int Case)
           
           if ( Case == 0 ) {
           
-             FPRINTF(StatusFile_,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",
+              FPRINTF(StatusFile_, "%9.5lf % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",
                      Time,
                      Mach_,
                      FLOAT(AngleOfAttack_/TORAD),
@@ -18419,7 +18419,7 @@ void VSP_SOLVER::OutputStatusFile(int Case)
              FPRINTF(StatusFile_,"\n\n\n");
              FPRINTF(StatusFile_,"Average Data: \n\n");
                               
-             FPRINTF(StatusFile_,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",
+             FPRINTF(StatusFile_,"%9.5lf % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",
                      Time,
                      Mach_,
                      FLOAT(AngleOfAttack_/TORAD),

--- a/src/vsp_aero/solver/vspaero.C
+++ b/src/vsp_aero/solver/vspaero.C
@@ -2263,8 +2263,8 @@ void Solve(void)
 
     }    
 
-                     //123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789      
-    FPRINTF(PolarFile,"  Beta      Mach       AoA      Re/1e6     CL         CDo       CDi      CDtot      CS        L/D        E        CFx       CFy       CFz       CMx       CMy       CMz       CMl       CMm       CMn      FOpt \n");
+                     //1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123 1234567890123
+    FPRINTF(PolarFile,"     Beta          Mach           AoA        Re/1e6            CL           CDo           CDi         CDtot            CS           L/D             E           CFx           CFy           CFz           CMx           CMy           CMz           CMl           CMm           CMn \n");
 
     // Write out polars, not these are written out in a different order than they were calculated above - we group them by Re number
     
@@ -2282,7 +2282,7 @@ void Solve(void)
    
                 E = ( CLForCase[Case] *CLForCase[Case] / ( PI * AR) ) / CDForCase[Case];
                 
-                FPRINTF(PolarFile,"%9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf %9.5lf\n",             
+                FPRINTF(PolarFile,"% 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E % 9E\n",             
                         BetaList_[i],
                         MachList_[j],
                         AoAList_[k],


### PR DESCRIPTION
Changes the output format for some VSPAERO output files to scientific notation.
This improves the performance of VSPAERO when used with optimization frameworks, as these output files contain the values the API returns. When the optimizer tries to obtain gradients by modifying parameters slightly, it may fail to capture the effects due to the low numerical precision of the output files.

additionally: fixes minor typos in the comments + reduces wait for file time