### PR TITLE
Fix various typos

### DIFF
--- a/examples/vspaero_ex/Isolated_Rotor/Steady_Rotating_Frame/README.md
+++ b/examples/vspaero_ex/Isolated_Rotor/Steady_Rotating_Frame/README.md
@@ -4,7 +4,7 @@ Instead of rotating the blades, the steady rotating frame approach used in this 
 holds the blades still and rotates the freestream around the X-axis.  This requires the
 model and flow to be symmetrical about (and aligned with) the X-axis.  The resulting
 flow is steady in the frame of the blades.  In this case, wake relaxation is used in the
-solution process.  However, the wake relaxation does not represent a time-accurate phenemona. 
+solution process.  However, the wake relaxation does not represent a time-accurate phenomena. 
 
 The `prop_DegenGeom.csv` file in this directory can be re-created by running the DegenGeom
 analysis in OpenVSP.

--- a/src/geom_core/DegenGeom.cpp
+++ b/src/geom_core/DegenGeom.cpp
@@ -403,7 +403,7 @@ void DegenGeom::createDegenPlate( DegenPlate &degenPlate, const vector< vector< 
             xVec[j]  = chordPnt;
 
             // This portion of the code implicitly assumes each section is flat.  For
-            // bodies with extreme skinning, this is likley not the case and unexpected results
+            // bodies with extreme skinning, this is likely not the case and unexpected results
             // may occur.
 
             vec3d zv = camberPnt - chordPnt;

--- a/src/geom_core/FeaStructure.cpp
+++ b/src/geom_core/FeaStructure.cpp
@@ -4049,7 +4049,7 @@ void FeaDome::BuildDomeSurf()
 
 void FeaDome::UpdateDrawObjs()
 {
-    // Two DrawObjs per Dome surface: index j correcponds to the surface (quads) and 
+    // Two DrawObjs per Dome surface: index j corresponds to the surface (quads) and 
     //  j + 1 corresponds to the cross section feature line at u_max 
 
     m_FeaPartDO.clear();

--- a/src/geom_core/Geom.cpp
+++ b/src/geom_core/Geom.cpp
@@ -849,7 +849,7 @@ void GeomXForm::AcceptScale()
 //  if (sym_code != NO_SYM)
 //    compose_reflect_matrix();
 //
-//  //==== Uppdate Children =====//
+//  //==== Update Children =====//
 //  for ( i = 0 ; i < (int)childGeomVec.size() ; i++ )
 //  {
 //  childGeomVec[i]->compose_model_matrix();

--- a/src/geom_core/ScriptMgr.cpp
+++ b/src/geom_core/ScriptMgr.cpp
@@ -7558,7 +7558,7 @@ void ScriptMgrSingleton::RegisterAPI( asIScriptEngine* se )
 
     doc_struct.comment = R"(
 /*!
-    Set the ower points for an airfoil. The XSec must be of type XS_FILE_AIRFOIL.
+    Set the lower points for an airfoil. The XSec must be of type XS_FILE_AIRFOIL.
     \code{.cpp}
     // Add Fuselage Geom
     string fuseid = AddGeom( "FUSELAGE", "" );
@@ -11726,7 +11726,7 @@ void ScriptMgrSingleton::RegisterAPI( asIScriptEngine* se )
 
     doc_struct.comment = R"(
 /*!
-    Delete a particular Ruler from the Meaure Tool
+    Delete a particular Ruler from the Measure Tool
     \code{.cpp}
     string pid1 = AddGeom( "POD", "" );
 
@@ -11751,7 +11751,7 @@ void ScriptMgrSingleton::RegisterAPI( asIScriptEngine* se )
 
     doc_struct.comment = R"(
 /*!
-    Delete all Rulers from the Meaure Tool
+    Delete all Rulers from the Measure Tool
     \code{.cpp}
     string pid1 = AddGeom( "POD", "" );
 

--- a/src/geom_core/XSecCurve.cpp
+++ b/src/geom_core/XSecCurve.cpp
@@ -1789,7 +1789,7 @@ void XSecCurve::Chevron()
     }
 
     // Set up chevron curve as if start is always at 0.0.
-    // This simplifies some of the logic including determing how many points are needed to define curve.
+    // This simplifies some of the logic including determining how many points are needed to define curve.
     int ptpercycle = 2;
     int peakpercycle = 1;
     int valleypercycle = 1;

--- a/src/gui_and_draw/GroupLayout.h
+++ b/src/gui_and_draw/GroupLayout.h
@@ -92,7 +92,7 @@ public:
     //==== Add Fixed Distance (GapHeight) To Y Location ====//
     void AddYGap()          { m_Y += m_GapHeight; }
 
-    //==== Move to Begininng of Next Line (ignore SameLineFlag) ====//
+    //==== Move to Beginning of Next Line (ignore SameLineFlag) ====//
     void ForceNewLine();
 
     //==== Flag To Force GuiDevices to Fill Complete Line Width ====//

--- a/src/gui_and_draw/SetEditorScreen.h
+++ b/src/gui_and_draw/SetEditorScreen.h
@@ -63,7 +63,7 @@ protected:
     TriggerButton m_CopySet;
     TriggerButton m_PasteSet;
 
-    //These buttons are for selecting all or none of the checkboxs in m_SetSelectBrowser
+    //These buttons are for selecting all or none of the checkboxes in m_SetSelectBrowser
     TriggerButton m_SelectAll;
     TriggerButton m_UnselectAll;
 

--- a/src/gui_and_draw/VarPresetScreen.cpp
+++ b/src/gui_and_draw/VarPresetScreen.cpp
@@ -184,8 +184,8 @@ bool VarPresetScreen::Update()
 
     // ==== Update Menus ==== //
     // This used to only update when a flag to update it was set or the 
-    // number of variable presets changed. THis was not working so was simplified
-    // to update the manues evey iteration. The additional time is negligible and 
+    // number of variable presets changed. This was not working so was simplified
+    // to update the menus every iteration. The additional time is negligible and 
     // this is consistent with updates for other menu items. 
     RebuildMenus( VarPresetMgr.GetActiveGroupIndex() );
 

--- a/src/test/py/tests/rst_test.py
+++ b/src/test/py/tests/rst_test.py
@@ -30,7 +30,7 @@ def test_rst():
     t1 = np.zeros([nr*ns, 1])
     d1 = np.zeros([nr*ns, 1])
 
-    # Preform RST projection on test points (this should give the rst points we defined in the step above)
+    # Perform RST projection on test points (this should give the rst points we defined in the step above)
     r1, s1, t1, d1 = vsp.FindRSTVec(geom_id, 0, pts0)
     # Evaluate the new rst projections in xyz (again, these should be the same points we found above)
     pts1 = vsp.CompVecPntRST(geom_id, 0, r1, s1, t1)

--- a/src/vsp_aero/Adb2Load/ADBSlicer.C
+++ b/src/vsp_aero/Adb2Load/ADBSlicer.C
@@ -435,7 +435,7 @@ void ADBSLICER::LoadMeshData(void)
        
     }
 
-    // Read in the default in to check on endianess
+    // Read in the default in to check on endianness
 
     BIO.fread(&DumInt, i_size, 1, adb_file);
 
@@ -919,7 +919,7 @@ void ADBSLICER::LoadSolutionData(int Case)
 
     } 
     
-    // Read in the default in to check on endianess
+    // Read in the default in to check on endianness
 
     BIO.fread(&DumInt, i_size, 1, adb_file);
 
@@ -2213,7 +2213,7 @@ void ADBSLICER::SmoothSkinThickness(char *filename1)
     char file_name_w_ext[10000], DumChar[10000], SearchLabel[10000];
     FILE *File1;
 
-    // Create a temp array for the elment data
+    // Create a temp array for the element data
         
     MaxElements = 250000;
         
@@ -2407,7 +2407,7 @@ void ADBSLICER::ResizeCalculixInputFileSkins(char *filename1, char *newfilename)
     MinThick = 1.e9;
     MaxThick = -1.e9;
 
-    // Create a temp array for the elment data
+    // Create a temp array for the element data
         
     MaxElements = 250000;
         
@@ -2759,7 +2759,7 @@ void ADBSLICER::ResizeCalculixInputFileSkinsOld(char *filename1, char *newfilena
     MinThick = 1.e9;
     MaxThick = -1.e9;
 
-    // Create a temp array for the elment data
+    // Create a temp array for the element data
         
     MaxElements = 250000;
         
@@ -4354,7 +4354,7 @@ void ADBSLICER::WriteOutCalculixStaticAnalysisFile(char *name, int AnalysisType)
               // strtok modifies base string contents, work from copy to leave DumChar un-changed.
               strcpy( DumChar2, DumChar );
 
-              // Position substr at first occurance of ELSET in DumChar
+              // Position substr at first occurrence of ELSET in DumChar
               substr = strstr( DumChar2, "ELSET" );
 
               // Separate element
@@ -4391,7 +4391,7 @@ void ADBSLICER::WriteOutCalculixStaticAnalysisFile(char *name, int AnalysisType)
               // strtok modifies base string contents, work from copy to leave DumChar un-changed.
               strcpy( DumChar2, DumChar );
 
-              // Position substr at first occurance of NAME in DumChar
+              // Position substr at first occurrence of NAME in DumChar
               substr = strstr( DumChar2, "NAME" );
 
               // Separate element
@@ -4423,7 +4423,7 @@ void ADBSLICER::WriteOutCalculixStaticAnalysisFile(char *name, int AnalysisType)
               // strtok modifies base string contents, work from copy to leave DumChar un-changed.
               strcpy( DumChar2, DumChar );
 
-              // Position substr at first occurance of NAME in DumChar
+              // Position substr at first occurrence of NAME in DumChar
               substr = strstr( DumChar2, "NAME" );
 
               substr = strtok( substr, "=" );

--- a/src/vsp_aero/Adb2Load/interp.C
+++ b/src/vsp_aero/Adb2Load/interp.C
@@ -634,7 +634,7 @@ void INTERP::InterpolateSolution(INTERP_MESH *Mesh1, INTERP_MESH *Mesh2)
 
     printf("Used closest point for %d nodes \n",closest);
 
-    printf("Turn off normal contraints for %d nodes \n",NormalOff);
+    printf("Turn off normal constraints for %d nodes \n",NormalOff);
 
     printf("Used a maximum radius of %d \n",max_radius);
 
@@ -676,7 +676,7 @@ void INTERP::WriteADBFile(INTERP_MESH *Mesh, char *Name)
 
     }
 
-    // Write out the default in to check on endianess
+    // Write out the default in to check on endianness
 
     DumInt = -123789456 + 4; // Version 4
 

--- a/src/vsp_aero/Adb2Load/interp.H
+++ b/src/vsp_aero/Adb2Load/interp.H
@@ -50,7 +50,7 @@ class INTERP_TRI
     int InterpNode[3];
     float InterpWeight[3];
     
-    char *ElementName; // Pointer to element group name, this is shared across all elements in the gorup
+    char *ElementName; // Pointer to element group name, this is shared across all elements in the grpup
 
 }; 
 // Node Structure

--- a/src/vsp_aero/Adb2Load/search.C
+++ b/src/vsp_aero/Adb2Load/search.C
@@ -294,7 +294,7 @@ int *merge_sort(LEAF *root)
 
     list_2 = (int *) calloc(root->number_of_nodes + 1, sizeof(int));
 
-    /* check that memory allocation was succesfull */
+    /* check that memory allocation was successful */
 
     if ( list_1 == NULL || list_2 == NULL ) {
 
@@ -304,7 +304,7 @@ int *merge_sort(LEAF *root)
 
     }
 
-    /* intialize the lists */
+    /* initialize the lists */
 
     for ( i = 1 ; i <= root->number_of_nodes ; i++ ) {
 

--- a/src/vsp_aero/Solver/BoundaryConditionData.H
+++ b/src/vsp_aero/Solver/BoundaryConditionData.H
@@ -41,7 +41,7 @@ public:
     
     int &HasHightLiftSlat(void) { return HasHightLiftSlat_; };
     
-    /** Percent of chord for the leading edge slat... acutally a fraction from 0 to 1. **/
+    /** Percent of chord for the leading edge slat... actually a fraction from 0 to 1. **/
     
     VSPAERO_DOUBLE &HighLiftSlatPercentage(void) { return HighLiftSlatPercentage_; };
     

--- a/src/vsp_aero/Solver/ComponentGroup.C
+++ b/src/vsp_aero/Solver/ComponentGroup.C
@@ -126,7 +126,7 @@ COMPONENT_GROUP::COMPONENT_GROUP(void)
     Cref_    = 0.;  
 
 
-    // Size and intialize matrices, vectors
+    // Size and initialize matrices, vectors
     
                 MassMatrix_.size(3,3);
              InertiaMatrix_.size(3,3);

--- a/src/vsp_aero/Solver/ComponentGroup.H
+++ b/src/vsp_aero/Solver/ComponentGroup.H
@@ -506,7 +506,7 @@ public:
     
     VSPAERO_DOUBLE &Bref(void) { return Bref_; };
     
-    /** Refererence chord **/
+    /** Reference chord **/
     
     VSPAERO_DOUBLE &Cref(void) { return Cref_; };    
         
@@ -546,7 +546,7 @@ public:
         
     VSPAERO_DOUBLE &Velocity(int i ) { return Velocity_(i+1); };
     
-    /** Angular velocity of group... typicall used to model a rotor **/
+    /** Angular velocity of group... typically used to model a rotor **/
      
     VSPAERO_DOUBLE &Omega(void) { return Omega_; };   
     

--- a/src/vsp_aero/Solver/ControlSurface.H
+++ b/src/vsp_aero/Solver/ControlSurface.H
@@ -180,7 +180,7 @@ public:
     
     char *Name(void) { return Name_; };
     
-    /** Short name given by openvsp to descriminate between control surfaces on various componets **/
+    /** Short name given by openvsp to discriminate between control surfaces on various components **/
     
     char *ShortName(void) { return ShortName_; };    
     

--- a/src/vsp_aero/Solver/InteractionLoop.H
+++ b/src/vsp_aero/Solver/InteractionLoop.H
@@ -53,7 +53,7 @@ public:
     
     /** Mesh level this list corresponds to, ie in the full multipole we may be calculating 
      * induced velocities for a group of loops (agglomerated) at a coarse level as we 
-     * have decided they are far enough away as a group to be considered a single evaulation
+     * have decided they are far enough away as a group to be considered a single evaluation
      * point... **/
 
     int &Level(void) { return Level_; };

--- a/src/vsp_aero/Solver/MergeSort.C
+++ b/src/vsp_aero/Solver/MergeSort.C
@@ -107,7 +107,7 @@ int* MERGESORT::merge_sort(int NumberOfEdges, VSP_EDGE **EdgeList)
 
     list_2 = new int[NumberOfEdges + 1];
 
-    // intialize the lists
+    // initialize the lists
 
     for ( i = 1 ; i <= NumberOfEdges ; i++ ) {
 

--- a/src/vsp_aero/Solver/QuadTree.C
+++ b/src/vsp_aero/Solver/QuadTree.C
@@ -390,7 +390,7 @@ int QUAD_TREE::InsertPoint(VSPAERO_DOUBLE xyzp[3], int SurfaceEdge)
     
     else {
        
-       PRINTF("Must specificy quad tree direction before inserting points! \n");fflush(NULL);
+       PRINTF("Must specify quad tree direction before inserting points! \n");fflush(NULL);
        exit(1);
        
     }

--- a/src/vsp_aero/Solver/RotorDisk.H
+++ b/src/vsp_aero/Solver/RotorDisk.H
@@ -117,7 +117,7 @@ public:
     
     void VelocityPotential(VSPAERO_DOUBLE xyz[3], VSPAERO_DOUBLE q[5]);
     
-    /** Intialize the rotor data **/
+    /** Initialize the rotor data **/
     
     void Initialize(void);
     

--- a/src/vsp_aero/Solver/Search.C
+++ b/src/vsp_aero/Solver/Search.C
@@ -334,7 +334,7 @@ int *SEARCH::merge_sort(SEARCH_LEAF *root)
 
     list_2 = new int[root->number_of_nodes + 1];
 
-    // check that memory allocation was succesfull 
+    // check that memory allocation was successful
 
     if ( list_1 == NULL || list_2 == NULL ) {
 
@@ -344,7 +344,7 @@ int *SEARCH::merge_sort(SEARCH_LEAF *root)
 
     }
 
-    // intialize the lists 
+    // initialize the lists 
 
     for ( i = 1 ; i <= root->number_of_nodes ; i++ ) {
 

--- a/src/vsp_aero/Solver/SpanLoadData.H
+++ b/src/vsp_aero/Solver/SpanLoadData.H
@@ -66,7 +66,7 @@ private:
     VSPAERO_DOUBLE *Span_Cs_;
     VSPAERO_DOUBLE *Span_Cd_;
     
-    // Mininum Local Cp
+    // Minimum Local Cp
 
     VSPAERO_DOUBLE *Span_CpMin_;    
     

--- a/src/vsp_aero/Solver/VSPAERO_TYPES.C
+++ b/src/vsp_aero/Solver/VSPAERO_TYPES.C
@@ -163,7 +163,7 @@ double AUTO_DIFF_STACK_MEMORY(void) {
 
 #ifdef AUTODIFF
    
-    // Get stack memory useage
+    // Get stack memory usage
 
     return (adept::active_stack()->memory()/(1.e9));
 

--- a/src/vsp_aero/Solver/VSPAERO_TYPES.H
+++ b/src/vsp_aero/Solver/VSPAERO_TYPES.H
@@ -16,7 +16,7 @@
 #include <complex>
 #endif
 
-// undef FWRITE/FREAD macors
+// undef FWRITE/FREAD macros
 // These function names can conflict with  macros found in fcntl.h
 #ifdef FWRITE
 #undef FWRITE

--- a/src/vsp_aero/Solver/VSP_Agglom.C
+++ b/src/vsp_aero/Solver/VSP_Agglom.C
@@ -509,7 +509,7 @@ void VSP_AGGLOM::InitializeFront_(void)
        
     }
        
-    // Check if edge is on any general boundry
+    // Check if edge is on any general boundary
        
     for ( i = 1 ; i <= FineGrid().NumberOfEdges() ; i++ ) {
               
@@ -2519,7 +2519,7 @@ void VSP_AGGLOM::CreateCoarseMesh_(void)
           PRINTF("Working on Loop: %d \n",i);
           PRINTF("NumberOfLoopNodes: %d \n",NumberOfLoopNodes);
           PRINTF("CoarseGrid().LoopList(i).NumberOfEdges(): %d \n",CoarseGrid().LoopList(i).NumberOfEdges());
-          PRINTF("These should be the same value if we assume a sensical mesh... but we problably coarsened too much! \n");
+          PRINTF("These should be the same value if we assume a sensical mesh... but we probably coarsened too much! \n");
           PRINTF("The solver will likely be fine... but you might want check the coarse meshes if this mesh is actually used... \n");
           fflush(NULL);
           
@@ -2599,7 +2599,7 @@ void VSP_AGGLOM::CreateCoarseMesh_(void)
           
           if ( !Found ) {
              
-             PRINTF("Error in determing UV surface mapping during agglomeration! \n");
+             PRINTF("Error in determining UV surface mapping during agglomeration! \n");
              fflush(NULL);
           //   exit(1);
              

--- a/src/vsp_aero/Solver/VSP_Edge.H
+++ b/src/vsp_aero/Solver/VSP_Edge.H
@@ -146,7 +146,7 @@ private:
     
     VSPAERO_DOUBLE KTFact_;
 
-    // Flag dermining which loops are down wind of this vortex edge
+    // Flag derminining which loops are down wind of this vortex edge
     
     int VortexLoop1IsDownWind_;
     int VortexLoop2IsDownWind_;
@@ -244,7 +244,7 @@ public:
     
     int &VortexLoop2(void) { return VortexLoop2_; };
 
-    /** Finite ore size **/
+    /** Finite core size **/
      
     VSPAERO_DOUBLE &Sigma(void) { return Sigma_; };
     

--- a/src/vsp_aero/Solver/VSP_Geom.C
+++ b/src/vsp_aero/Solver/VSP_Geom.C
@@ -1569,7 +1569,7 @@ void VSP_GEOM::MeshGeom(void)
     PRINTF("NumberOfGridLevels_: %d \n",NumberOfGridLevels_);    
     PRINTF("NumberOfSurfacePatches_: %d \n",NumberOfSurfacePatches_);
     
-    // Ouput the coarse grid mesh info
+    // Output the coarse grid mesh info
     
     if ( Verbose_ ) OutputCoarseGridInfo();
 

--- a/src/vsp_aero/Solver/VSP_Grid.C
+++ b/src/vsp_aero/Solver/VSP_Grid.C
@@ -760,7 +760,7 @@ void VSP_GRID::CreateTriEdges(void)
 
     }
         
-    // Mark edges on boarders of diffrent surface IDs, and calculate normal
+    // Mark edges on boarders of different surface IDs, and calculate normal
     
     for ( i = 1 ; i <= NumberOfEdges() ; i++ ) {
        
@@ -1012,7 +1012,7 @@ void VSP_GRID::CreateUpwindEdgeData(void)
    
     for ( j = 1 ; j <= NumberOfEdges() ; j++ ) {
 
-       // Pass in edge data and create edge cofficients
+       // Pass in edge data and create edge coefficients
        
        Node1 = EdgeList(j).Node1();
        Node2 = EdgeList(j).Node2();

--- a/src/vsp_aero/Solver/VSP_Grid.H
+++ b/src/vsp_aero/Solver/VSP_Grid.H
@@ -248,7 +248,7 @@ public:
     
     void CreateUpwindEdgeData(void);
     
-    /** Contraint on the minimum loop sized used during agglomeration **/
+    /** Constraint on the minimum loop sized used during agglomeration **/
     
     VSPAERO_DOUBLE &MinLoopArea(void) { return MinLoopArea_; };
 

--- a/src/vsp_aero/Solver/VSP_Optimizer.H
+++ b/src/vsp_aero/Solver/VSP_Optimizer.H
@@ -540,9 +540,9 @@ public:
     
     void WriteOutCart3dTriFile(void) { Solver().WriteOutCart3dTriFile(); };
 
-    /** Supress/resume stdout **/
+    /** Suppress/resume stdout **/
 
-    void SupressStdout(void);
+    void SuppressStdout(void);
     void ResumeStdout(void);
 
 };

--- a/src/vsp_aero/Solver/VSP_Solver.C
+++ b/src/vsp_aero/Solver/VSP_Solver.C
@@ -756,7 +756,7 @@ void VSP_SOLVER::Setup(void)
           
           if ( ComponentGroupList_[c].ComponentList(j) > VSPGeom().NumberOfComponents() ) {
              
-             PRINTF("Component Group: %d lists non-existant Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
+             PRINTF("Component Group: %d lists non-existent Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
              
              fflush(NULL);exit(1);
           
@@ -937,7 +937,7 @@ void VSP_SOLVER::Setup(void)
           
           if ( ComponentGroupList_[c].ComponentList(j) > VSPGeom().NumberOfComponents() ) {
              
-             PRINTF("Component Group: %d lists non-existant Component: %d \n", c, ComponentGroupList_[c].ComponentList(j)); fflush(NULL);
+             PRINTF("Component Group: %d lists non-existent Component: %d \n", c, ComponentGroupList_[c].ComponentList(j)); fflush(NULL);
              
              fflush(NULL);exit(1);
           
@@ -1315,7 +1315,7 @@ void VSP_SOLVER::Setup(void)
     
     }
     
-    // Uknown model
+    // Unknown model
     
     else {
        
@@ -1776,7 +1776,7 @@ void VSP_SOLVER::Setup(void)
           
           if ( EngineFace_[i].SurfaceID() <= 0 || EngineFace_[i].SurfaceID() > VSPGeom().VSP_Surface(1).NumberOfSurfacePatches() ) {
              
-             PRINTF("Error... engine %d points to non-existant surface: %d \n",i,EngineFace_[i].SurfaceID()); fflush(NULL);
+             PRINTF("Error... engine %d points to non-existent surface: %d \n",i,EngineFace_[i].SurfaceID()); fflush(NULL);
              
           }
           
@@ -2945,7 +2945,7 @@ void VSP_SOLVER::InitializeTrailingVortices(void)
     PRINTF("Wake FarDist set to: %f \n",FarDist);
     PRINTF("\n");
        
-    // Set intial wake start time
+    // Set initial wake start time
     
     WakeStartingTime_ = 0;
     
@@ -5135,7 +5135,7 @@ void VSP_SOLVER::RestartAndInterrogateSolution(int Case)
  
        }    
        
-       // Update geometry location and interaction lists for moving geoemtries
+       // Update geometry location and interaction lists for moving geometries
 
        if ( TimeAccurate_ ) UpdateGeometryLocation(0);     
   
@@ -5450,7 +5450,7 @@ void VSP_SOLVER::WriteOutSteadyStateNoiseFiles(int Case)
 
        if ( Time_ == NumberOfTimeSteps_ - 1 ) { for ( c = 1 ; c <= NumberOfComponentGroups_ ; c++ ) WriteOutPSUWopWopUnsteadyDataForGroup(c); };
 
-       // Update geometry location and interaction lists for moving geoemtries
+       // Update geometry location and interaction lists for moving geometries
        
        UpdateGeometryLocation(0);     
          
@@ -5949,7 +5949,7 @@ void VSP_SOLVER::WriteOutTimeAccurateNoiseFiles(int Case)
 
           WriteOutPSUWopWopUnsteadyDataForGroup(c);
   
-          // Update geometry location and interaction lists for moving geoemtries
+          // Update geometry location and interaction lists for moving geometries
           
           UpdateGeometryLocation(0);    
              
@@ -7438,7 +7438,7 @@ void VSP_SOLVER::DoMatrixPrecondition(VSPAERO_DOUBLE *vec_in)
 
     }
     
-    // Matrix precondtioner
+    // Matrix preconditioner
     
     else if ( Preconditioner_ == MATCON ) {
 
@@ -11130,7 +11130,7 @@ void VSP_SOLVER::Optimization_Calculate_Total_Gradient(void)
        
        }
        
-       // Save the current gradient with respect to the input varialbes if this is an unsteady case
+       // Save the current gradient with respect to the input variables if this is an unsteady case
        
        for ( i = 1 ; i <= NumberOfOptimizationInputIndepdendentVariables_ ; i++ ) {
           
@@ -11768,7 +11768,7 @@ void VSP_SOLVER::CalculateResidual(void)
    
     else if ( ModelType_ == PANEL_MODEL ) {
        
-       // Matrix vector of the linear system... enforncing tangency
+       // Matrix vector of the linear system... enforcing tangency
 
        MatrixMultiply(Gamma_[0], Residual_);
 
@@ -11877,7 +11877,7 @@ void VSP_SOLVER::CalculateMatrixVectorProductAndRightHandSide(double *VecIn, dou
    
     else if ( ModelType_ == PANEL_MODEL ) {
        
-       // Matrix vector of the linear system... enforncing tangency
+       // Matrix vector of the linear system... enforcing tangency
 
        MatrixMultiply(VecIn, MatrixVecTemp_);
        
@@ -16573,7 +16573,7 @@ int VSP_SOLVER::SurfaceVortexEdgeIsBetweenPlanes(VSPAERO_DOUBLE *Normal1, VSPAER
 
     if ( Type1 == 0 ) { Weight = 1. ; return 1; };
        
-    // Segement is parallel with plane, but does not intersect it
+    // Segment is parallel with plane, but does not intersect it
     
     if ( Type1 == -1 ) { Weight = 1. ; return 1; };
     
@@ -16583,7 +16583,7 @@ int VSP_SOLVER::SurfaceVortexEdgeIsBetweenPlanes(VSPAERO_DOUBLE *Normal1, VSPAER
 
     if ( Type2 == 0 ) { Weight = 1. ; return 1; };
        
-    // Segement is parallel with plane, but does not intersect it
+    // Segment is parallel with plane, but does not intersect it
     
     if ( Type2 == -1 ) { Weight = 1. ; return 1; };    
     
@@ -18476,7 +18476,7 @@ void VSP_SOLVER::WriteOutAerothermalDatabaseHeader(void)
     c_size = sizeof(char);
     f_size = sizeof(float);
 
-    // Write out coded id to allow us to determine endiannes of files
+    // Write out coded id to allow us to determine endianness of files
 
     DumInt = -123789456 + 3; // Version 3 of the ADB file
 
@@ -18629,7 +18629,7 @@ void VSP_SOLVER::ReadInAerothermalDatabaseHeader(void)
     c_size = sizeof(char);
     f_size = sizeof(float);
 
-    // Read in endiannes of files
+    // Read in endianness of files
 
     FREAD(&DumInt, i_size, 1, InputADBFile_);
     
@@ -27253,7 +27253,7 @@ void VSP_SOLVER::WriteOutPSUWopWopBPMHeaderForGroup(int c)
        NumberJ = VSPGeom().VSP_Surface(k).NumberOfSpanStations();
     
        DumInt = 42; FWRITE(&(DumInt ), i_size, 1, WopFile); // Magic Number
-                    FWRITE(&(NumberJ), i_size, 1, WopFile); // Number of sections definining the blade
+                    FWRITE(&(NumberJ), i_size, 1, WopFile); // Number of sections defining the blade
        DumInt =  0; FWRITE(&(DumInt ), i_size, 1, WopFile); // Non-uniform blade sections
        DumInt =  1; FWRITE(&(DumInt ), i_size, 1, WopFile); // Blade section chord data provided
        DumInt =  0; FWRITE(&(DumInt ), i_size, 1, WopFile); // Blade section length data not provided

--- a/src/vsp_aero/Solver/VSP_Solver.C.3.Aug.2021
+++ b/src/vsp_aero/Solver/VSP_Solver.C.3.Aug.2021
@@ -583,7 +583,7 @@ void VSP_SOLVER::Setup(void)
           
           if ( ComponentGroupList_[c].ComponentList(j) > VSPGeom().NumberOfComponents() ) {
              
-             PRINTF("Component Group: %d lists non-existant Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
+             PRINTF("Component Group: %d lists non-existent Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
              
              fflush(NULL);exit(1);
           
@@ -711,7 +711,7 @@ void VSP_SOLVER::Setup(void)
           
           if ( ComponentGroupList_[c].ComponentList(j) > VSPGeom().NumberOfComponents() ) {
              
-             PRINTF("Component Group: %d lists non-existant Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
+             PRINTF("Component Group: %d lists non-existent Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
              
              fflush(NULL);exit(1);
           
@@ -1026,7 +1026,7 @@ void VSP_SOLVER::Setup(void)
     
     }
     
-    // Uknown model
+    // Unknown model
     
     else {
        
@@ -1833,7 +1833,7 @@ void VSP_SOLVER::Setup_VortexEdges(void)
    
           VSPGeom().Grid(Level).EdgeList(j).VortexEdge() = ++k;
           
-          // Pass in edge data and create edge cofficients
+          // Pass in edge data and create edge coefficients
           
           Node1 = VSPGeom().Grid(Level).EdgeList(j).Node1();
           Node2 = VSPGeom().Grid(Level).EdgeList(j).Node2();
@@ -2302,7 +2302,7 @@ void VSP_SOLVER::InitializeTrailingVortices(void)
     PRINTF("Wake FarDist set to: %f \n",FarDist);
     PRINTF("\n");
        
-    // Set intial wake start time
+    // Set initial wake start time
     
     WakeStartingTime_ = 0;
     
@@ -2660,7 +2660,7 @@ void VSP_SOLVER::InitializeTrailingVortices(void)
                    
                 }                             
                                                                     
-                // Pass in edge data and create edge cofficients
+                // Pass in edge data and create edge coefficients
                 
                 VSP_Node1.x() = VSPGeom().Grid(MGLevel_).WakeTrailingEdgeX(j);
                 VSP_Node1.y() = VSPGeom().Grid(MGLevel_).WakeTrailingEdgeY(j);
@@ -3613,7 +3613,7 @@ void VSP_SOLVER::Solve(int Case)
         
     }
 
-    // Update geometry location and interaction lists for moving geoemtries
+    // Update geometry location and interaction lists for moving geometries
 
     CurrentTime_ = CurrentNoiseTime_ = 0.;
            
@@ -3906,7 +3906,7 @@ void VSP_SOLVER::Solve(int Case)
 
           if ( TimeAccurate_ ) {
    
-             // Update geometry location and interaction lists for moving geoemtries
+             // Update geometry location and interaction lists for moving geometries
 
              if ( !StartFromSteadyState_ || ( StartFromSteadyState_ && Time_ > 1 ) ) UpdateGeometryLocation(0);
 
@@ -4380,7 +4380,7 @@ void VSP_SOLVER::WriteOutSteadyStateNoiseFiles(int Case)
 
        if ( Time_ == NumberOfTimeSteps_ - 1 ) { for ( c = 1 ; c <= NumberOfComponentGroups_ ; c++ ) WriteOutPSUWopWopUnsteadyDataForGroup(c); };
 
-       // Update geometry location and interaction lists for moving geoemtries
+       // Update geometry location and interaction lists for moving geometries
        
        UpdateGeometryLocation(0);     
          
@@ -4875,7 +4875,7 @@ void VSP_SOLVER::WriteOutTimeAccurateNoiseFiles(int Case)
 
           WriteOutPSUWopWopUnsteadyDataForGroup(c);
   
-          // Update geometry location and interaction lists for moving geoemtries
+          // Update geometry location and interaction lists for moving geometries
           
           UpdateGeometryLocation(0);    
              
@@ -6242,7 +6242,7 @@ void VSP_SOLVER::DoMatrixPrecondition(VSPAERO_DOUBLE *vec_in)
 
     }
     
-    // Matrix precondtioner
+    // Matrix preconditioner
     
     else if ( Preconditioner_ == MATCON ) {
 
@@ -8493,7 +8493,7 @@ void VSP_SOLVER::UpdateGeometryLocation(int DoStartUp)
                                 
              }         
              
-             // Update the least squares cofficients for the panel solver
+             // Update the least squares coefficients for the panel solver
              
              if ( ModelType_ == PANEL_MODEL ) {
                 
@@ -8721,7 +8721,7 @@ void VSP_SOLVER::ResetGeometry(void)
                                 
              }                      
              
-             // Update the least squares cofficients for the panel solver
+             // Update the least squares coefficients for the panel solver
              
              if ( ModelType_ == PANEL_MODEL ) {
                 
@@ -10241,7 +10241,7 @@ void VSP_SOLVER::CalculateForces(void)
     OptimizationFunction_[OPT_CMy] = CMy_[0];
     OptimizationFunction_[OPT_CMz] = CMz_[0];
     
-    // L/D with an attemp to hold CL constant
+    // L/D with an attempt to hold CL constant
     
     CLReq = 0.1800;
     
@@ -13198,7 +13198,7 @@ int VSP_SOLVER::SurfaceVortexEdgeIsBetweenPlanes(VSPAERO_DOUBLE *Normal1, VSPAER
 
     if ( Type1 == 0 ) { Weight = 1. ; return 1; };
        
-    // Segement is parallel with plane, but does not intersect it
+    // Segment is parallel with plane, but does not intersect it
     
     if ( Type1 == -1 ) { Weight = 1. ; return 1; };
     
@@ -13208,7 +13208,7 @@ int VSP_SOLVER::SurfaceVortexEdgeIsBetweenPlanes(VSPAERO_DOUBLE *Normal1, VSPAER
 
     if ( Type2 == 0 ) { Weight = 1. ; return 1; };
        
-    // Segement is parallel with plane, but does not intersect it
+    // Segment is parallel with plane, but does not intersect it
     
     if ( Type2 == -1 ) { Weight = 1. ; return 1; };    
     
@@ -14207,7 +14207,7 @@ void VSP_SOLVER::WriteOutAerothermalDatabaseHeader(void)
     c_size = sizeof(char);
     f_size = sizeof(float);
 
-    // Write out coded id to allow us to determine endiannes of files
+    // Write out coded id to allow us to determine endianness of files
 
     DumInt = -123789456; // Version 2 of the ADB file
 
@@ -14344,7 +14344,7 @@ void VSP_SOLVER::ReadInAerothermalDatabaseHeader(void)
     c_size = sizeof(char);
     f_size = sizeof(float);
 
-    // Read in endiannes of files
+    // Read in endianness of files
 
     FREAD(&DumInt, i_size, 1, InputADBFile_);
     
@@ -22437,7 +22437,7 @@ void VSP_SOLVER::WriteOutPSUWopWopBPMHeaderForGroup(int c)
        NumberJ = VSPGeom().VSP_Surface(k).NumberOfSpanStations();
     
        DumInt = 42; FWRITE(&(DumInt ), i_size, 1, WopFile); // Magic Number
-                    FWRITE(&(NumberJ), i_size, 1, WopFile); // Number of sections definining the blade
+                    FWRITE(&(NumberJ), i_size, 1, WopFile); // Number of sections defining the blade
        DumInt =  0; FWRITE(&(DumInt ), i_size, 1, WopFile); // Non-uniform blade sections
        DumInt =  1; FWRITE(&(DumInt ), i_size, 1, WopFile); // Blade section chord data provided
        DumInt =  0; FWRITE(&(DumInt ), i_size, 1, WopFile); // Blade section length data not provided

--- a/src/vsp_aero/Solver/VSP_Solver.H
+++ b/src/vsp_aero/Solver/VSP_Solver.H
@@ -139,7 +139,7 @@ private:
     
     VSPAERO_DOUBLE KelvinLambda_;
     
-    // Rotor Geoemtry
+    // Rotor Geometry
     
     int NumberOfRotors_;
     
@@ -420,7 +420,7 @@ private:
     
     void CalculateDiagonal(void);
     
-    // Calculate nearest neighbor coeffients of the influence matrix
+    // Calculate nearest neighbor coefficients of the influence matrix
     
     void CalculateNeighborCoefs(void);
     
@@ -619,7 +619,7 @@ private:
     
     void ResetGeometry(void);
 
-    // Update the local values of the circulation strengths for each vortex egde
+    // Update the local values of the circulation strengths for each vortex edge
     
     void UpdateVortexEdgeStrengths(int Level, int UpdateType);
     
@@ -1032,7 +1032,7 @@ public:
     
     VSP_NODE &SurveyPointList(int i) { return SurveyPointList_[i]; };
     
-    /** Set the number of final time steps to do a survey for unsteady calculatons **/
+    /** Set the number of final time steps to do a survey for unsteady calculations **/
     
     int &NumberOfSurveyTimeSteps(void) { return NumberOfSurveyTimeSteps_; };
     
@@ -1488,7 +1488,7 @@ void CalculateAdjointMatrixVectorProductAndRightHandSide(double *VecIn, double *
 
     void DoWopWopFlyBy(void) { WopWopFlyBy_ = 1; };
     
-    /** Do a psuwopwop foot print analysis **/
+    /** Do a psuwopwop footprint analysis **/
     
     void DoWopWopFootPrint(void) { WopWopFlyBy_ = 0; };
     
@@ -1532,7 +1532,7 @@ void CalculateAdjointMatrixVectorProductAndRightHandSide(double *VecIn, double *
     
     void CalculateOptimizationFunctionLength(void);
    
-    /** Get optimization function lenght for opt function Case **/
+    /** Get optimization function length for opt function Case **/
     
     int OptimizationFunctionLength(int Case) { return OptimizationFunctionList_[Case].FunctionLength(); };
     
@@ -1551,7 +1551,7 @@ void CalculateAdjointMatrixVectorProductAndRightHandSide(double *VecIn, double *
     /** This is an optimization solve
      * 
      * this must be set to let the solver know it needs to evaluate the 
-     * optimization functions... for both the foward and adjoint solvers
+     * optimization functions... for both the forward and adjoint solvers
      * 
      **/
 
@@ -1593,7 +1593,7 @@ void CalculateAdjointMatrixVectorProductAndRightHandSide(double *VecIn, double *
 
     double dF_dMesh_Z(int p, int Time, int i) { return DOUBLE(dF_dMesh_[Time][p][3*i  ]); };
         
-    /** Total gradient of objective function 1 with resepect to input variable InputVariable 
+    /** Total gradient of objective function 1 with respect to input variable InputVariable 
      *
      * OPT_GRADIENT_WRT_ALPHA 
      * OPT_GRADIENT_WRT_BETA         
@@ -1608,7 +1608,7 @@ void CalculateAdjointMatrixVectorProductAndRightHandSide(double *VecIn, double *
     
     double dF_dInputVariable(int InputVariable) { return DOUBLE(dF_dInputVariable_[0][1][InputVariable]); };
  
-    /** Total gradient of objective function p with resepect to input variable InputVariable 
+    /** Total gradient of objective function p with respect to input variable InputVariable 
      *
      * OPT_GRADIENT_WRT_ALPHA 
      * OPT_GRADIENT_WRT_BETA         
@@ -1623,7 +1623,7 @@ void CalculateAdjointMatrixVectorProductAndRightHandSide(double *VecIn, double *
 
     double dF_dInputVariable(int p, int InputVariable) { return DOUBLE(dF_dInputVariable_[0][p][InputVariable]); };
     
-    /** Unsteady total gradient of objective function p, at time Time, with resepect to input variable InputVariable
+    /** Unsteady total gradient of objective function p, at time Time, with respect to input variable InputVariable
      *
      * OPT_GRADIENT_WRT_ALPHA 
      * OPT_GRADIENT_WRT_BETA         

--- a/src/vsp_aero/Solver/VSP_Solver.H.3.Aug.2021
+++ b/src/vsp_aero/Solver/VSP_Solver.H.3.Aug.2021
@@ -141,7 +141,7 @@ private:
     
     VSPAERO_DOUBLE KelvinLambda_;
     
-    // Rotor Geoemtry
+    // Rotor Geometry
     
     int NumberOfRotors_;
     
@@ -392,7 +392,7 @@ private:
     
     void CalculateDiagonal(void);
     
-    // Calculate nearest neighbor coeffients of the influence matrix
+    // Calculate nearest neighbor coefficients of the influence matrix
     
     void CalculateNeighborCoefs(void);
     
@@ -870,7 +870,7 @@ public:
     void UpdateGeometryLocation(int DoStartUp);
     void ResetGeometry(void);
 
-    // Update the local values of the circulation strengths for each vortex egde
+    // Update the local values of the circulation strengths for each vortex edge
     
     void UpdateVortexEdgeStrengths(int Level, int UpdateType);
     

--- a/src/vsp_aero/Solver/VSP_Solver.Reworked.3.Aug.2021
+++ b/src/vsp_aero/Solver/VSP_Solver.Reworked.3.Aug.2021
@@ -583,7 +583,7 @@ void VSP_SOLVER::Setup(void)
           
           if ( ComponentGroupList_[c].ComponentList(j) > VSPGeom().NumberOfComponents() ) {
              
-             PRINTF("Component Group: %d lists non-existant Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
+             PRINTF("Component Group: %d lists non-existent Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
              
              fflush(NULL);exit(1);
           
@@ -711,7 +711,7 @@ void VSP_SOLVER::Setup(void)
           
           if ( ComponentGroupList_[c].ComponentList(j) > VSPGeom().NumberOfComponents() ) {
              
-             PRINTF("Component Group: %d lists non-existant Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
+             PRINTF("Component Group: %d lists non-existent Component: %d \n", c, ComponentGroupList_[c].ComponentList(j));
              
              fflush(NULL);exit(1);
           
@@ -1026,7 +1026,7 @@ void VSP_SOLVER::Setup(void)
     
     }
     
-    // Uknown model
+    // Unknown model
     
     else {
        
@@ -1833,7 +1833,7 @@ void VSP_SOLVER::Setup_VortexEdges(void)
    
           VSPGeom().Grid(Level).EdgeList(j).VortexEdge() = ++k;
           
-          // Pass in edge data and create edge cofficients
+          // Pass in edge data and create edge coefficients
           
           Node1 = VSPGeom().Grid(Level).EdgeList(j).Node1();
           Node2 = VSPGeom().Grid(Level).EdgeList(j).Node2();
@@ -2302,7 +2302,7 @@ void VSP_SOLVER::InitializeTrailingVortices(void)
     PRINTF("Wake FarDist set to: %f \n",FarDist);
     PRINTF("\n");
        
-    // Set intial wake start time
+    // Set initial wake start time
     
     WakeStartingTime_ = 0;
     
@@ -2660,7 +2660,7 @@ void VSP_SOLVER::InitializeTrailingVortices(void)
                    
                 }                             
                                                                     
-                // Pass in edge data and create edge cofficients
+                // Pass in edge data and create edge coefficients
                 
                 VSP_Node1.x() = VSPGeom().Grid(MGLevel_).WakeTrailingEdgeX(j);
                 VSP_Node1.y() = VSPGeom().Grid(MGLevel_).WakeTrailingEdgeY(j);
@@ -3613,7 +3613,7 @@ void VSP_SOLVER::Solve(int Case)
         
     }
 
-    // Update geometry location and interaction lists for moving geoemtries
+    // Update geometry location and interaction lists for moving geometries
 
     CurrentTime_ = CurrentNoiseTime_ = 0.;
            
@@ -3908,7 +3908,7 @@ printf("How the fuck did I get here? \n");fflush(NULL);exit(1);
 
           if ( TimeAccurate_ ) {
    
-             // Update geometry location and interaction lists for moving geoemtries
+             // Update geometry location and interaction lists for moving geometries
 
              if ( !StartFromSteadyState_ || ( StartFromSteadyState_ && Time_ > 1 ) ) UpdateGeometryLocation(0);
 
@@ -4382,7 +4382,7 @@ void VSP_SOLVER::WriteOutSteadyStateNoiseFiles(int Case)
 
        if ( Time_ == NumberOfTimeSteps_ - 1 ) { for ( c = 1 ; c <= NumberOfComponentGroups_ ; c++ ) WriteOutPSUWopWopUnsteadyDataForGroup(c); };
 
-       // Update geometry location and interaction lists for moving geoemtries
+       // Update geometry location and interaction lists for moving geometries
        
        UpdateGeometryLocation(0);     
          
@@ -4877,7 +4877,7 @@ void VSP_SOLVER::WriteOutTimeAccurateNoiseFiles(int Case)
 
           WriteOutPSUWopWopUnsteadyDataForGroup(c);
   
-          // Update geometry location and interaction lists for moving geoemtries
+          // Update geometry location and interaction lists for moving geometries
           
           UpdateGeometryLocation(0);    
              
@@ -6244,7 +6244,7 @@ void VSP_SOLVER::DoMatrixPrecondition(VSPAERO_DOUBLE *vec_in)
 
     }
     
-    // Matrix precondtioner
+    // Matrix preconditioner
     
     else if ( Preconditioner_ == MATCON ) {
 
@@ -8495,7 +8495,7 @@ void VSP_SOLVER::UpdateGeometryLocation(int DoStartUp)
                                 
              }         
              
-             // Update the least squares cofficients for the panel solver
+             // Update the least squares coefficients for the panel solver
              
              if ( ModelType_ == PANEL_MODEL ) {
                 
@@ -8723,7 +8723,7 @@ void VSP_SOLVER::ResetGeometry(void)
                                 
              }                      
              
-             // Update the least squares cofficients for the panel solver
+             // Update the least squares coefficients for the panel solver
              
              if ( ModelType_ == PANEL_MODEL ) {
                 
@@ -10281,7 +10281,7 @@ void VSP_SOLVER::CalculateForces(void)
     OptimizationFunction_[OPT_CMy] = CMy_[0];
     OptimizationFunction_[OPT_CMz] = CMz_[0];
     
-    // L/D with an attemp to hold CL constant
+    // L/D with an attempt to hold CL constant
     
     CLReq = 0.1800;
     
@@ -13238,7 +13238,7 @@ int VSP_SOLVER::SurfaceVortexEdgeIsBetweenPlanes(VSPAERO_DOUBLE *Normal1, VSPAER
 
     if ( Type1 == 0 ) { Weight = 1. ; return 1; };
        
-    // Segement is parallel with plane, but does not intersect it
+    // Segment is parallel with plane, but does not intersect it
     
     if ( Type1 == -1 ) { Weight = 1. ; return 1; };
     
@@ -13248,7 +13248,7 @@ int VSP_SOLVER::SurfaceVortexEdgeIsBetweenPlanes(VSPAERO_DOUBLE *Normal1, VSPAER
 
     if ( Type2 == 0 ) { Weight = 1. ; return 1; };
        
-    // Segement is parallel with plane, but does not intersect it
+    // Segment is parallel with plane, but does not intersect it
     
     if ( Type2 == -1 ) { Weight = 1. ; return 1; };    
     
@@ -14247,7 +14247,7 @@ void VSP_SOLVER::WriteOutAerothermalDatabaseHeader(void)
     c_size = sizeof(char);
     f_size = sizeof(float);
 
-    // Write out coded id to allow us to determine endiannes of files
+    // Write out coded id to allow us to determine endianness of files
 
     DumInt = -123789456; // Version 2 of the ADB file
 
@@ -14384,7 +14384,7 @@ void VSP_SOLVER::ReadInAerothermalDatabaseHeader(void)
     c_size = sizeof(char);
     f_size = sizeof(float);
 
-    // Read in endiannes of files
+    // Read in endianness of files
 
     FREAD(&DumInt, i_size, 1, InputADBFile_);
     
@@ -22477,7 +22477,7 @@ void VSP_SOLVER::WriteOutPSUWopWopBPMHeaderForGroup(int c)
        NumberJ = VSPGeom().VSP_Surface(k).NumberOfSpanStations();
     
        DumInt = 42; FWRITE(&(DumInt ), i_size, 1, WopFile); // Magic Number
-                    FWRITE(&(NumberJ), i_size, 1, WopFile); // Number of sections definining the blade
+                    FWRITE(&(NumberJ), i_size, 1, WopFile); // Number of sections defining the blade
        DumInt =  0; FWRITE(&(DumInt ), i_size, 1, WopFile); // Non-uniform blade sections
        DumInt =  1; FWRITE(&(DumInt ), i_size, 1, WopFile); // Blade section chord data provided
        DumInt =  0; FWRITE(&(DumInt ), i_size, 1, WopFile); // Blade section length data not provided

--- a/src/vsp_aero/Solver/VSP_Surface.C
+++ b/src/vsp_aero/Solver/VSP_Surface.C
@@ -503,7 +503,7 @@ void VSP_SURFACE::ReadCart3DDataFromFile(char *Name, FILE *CART3D_File, FILE *TK
        
        if ( !Done ) {
           
-          PRINTF("Error in determing number of surfaces in CART3D file! \n");
+          PRINTF("Error in determining number of surfaces in CART3D file! \n");
           fflush(NULL);
           exit(1);
           
@@ -936,7 +936,7 @@ void VSP_SURFACE::ReadVSPGeomDataFromFile(char *Name, FILE *VSPGeom_File, FILE *
        
        if ( !Done ) {
           
-          PRINTF("Error in determing number of surfaces in VSPGEOM file! \n");
+          PRINTF("Error in determining number of surfaces in VSPGEOM file! \n");
           fflush(NULL);
           exit(1);
           
@@ -2324,7 +2324,7 @@ void VSP_SURFACE::ReadWingDataFromFile(char *Name, FILE *VSP_Degen_File)
     
     SizeFlatPlateLists(NumI,NumJ);
     
-    // Read in the flate plate Normal information
+    // Read in the flat plate Normal information
     
     fgets(DumChar,1000,VSP_Degen_File);  
 
@@ -5372,7 +5372,7 @@ void VSP_SURFACE::CreateUpwindEdgeData(int SurfaceID)
 
        }       
 
-       // Pass in edge data and create edge cofficients
+       // Pass in edge data and create edge coefficients
        
        Node1 = Grid().EdgeList(j).Node1();
        Node2 = Grid().EdgeList(j).Node2();

--- a/src/vsp_aero/Solver/VSP_Surface.H
+++ b/src/vsp_aero/Solver/VSP_Surface.H
@@ -145,7 +145,7 @@ private:
     
     VSPAERO_DOUBLE *Camber_;
     
-    // Control surface subsurface bouding boxes
+    // Control surface subsurface bounding boxes
     
     int MaxNumberOfControlSurfaces_;
     int NumberOfControlSurfaces_;

--- a/src/vsp_aero/Solver/Vortex_Sheet.C
+++ b/src/vsp_aero/Solver/Vortex_Sheet.C
@@ -988,7 +988,7 @@ void VORTEX_SHEET::SetupPlanarVortexSheets(void)
        
     }    
     
-    // Set unqiue sheet ID
+    // Set unique sheet ID
     
     j = 0;
    
@@ -1247,7 +1247,7 @@ void VORTEX_SHEET::SetupCircularVortexSheets(void)
        
     }  
      
-    // Set unqiue sheet ID
+    // Set unique sheet ID
     
     j = 0;
    

--- a/src/vsp_aero/Solver/Vortex_Sheet.H
+++ b/src/vsp_aero/Solver/Vortex_Sheet.H
@@ -399,7 +399,7 @@ public:
    
     VSPAERO_DOUBLE StartingGamma(int i, int j) { return StartingGamma_[i][j]; };
     
-    /** Flag to do ground effect analyis **/
+    /** Flag to do ground effect analysis **/
  
     int &DoGroundEffectsAnalysis(void) { return DoGroundEffectsAnalysis_; };
     
@@ -457,7 +457,7 @@ public:
 
     int NumberOfCommonTE(void) { return NumberOfCommonTE_; };
     
-    /** Number of commond nodes that share this xyz location **/
+    /** Number of common nodes that share this xyz location **/
     
     int &NumberOfCommonNodesForTE(int i) { return NumberOfCommonNodesForTE_[i]; };
     

--- a/src/vsp_aero/Solver/Vortex_Trail.C
+++ b/src/vsp_aero/Solver/Vortex_Trail.C
@@ -1593,7 +1593,7 @@ VSPAERO_DOUBLE VORTEX_TRAIL::UpdateWakeLocation(void)
           
           Dot1 = vector_dot(Vec,RotorThrustVector_);
           
-          // Component in direction of the vector from the rotor to the free stram direction
+          // Component in direction of the vector from the rotor to the free stream direction
           
           Vec3[0] = FreeStreamDirection_[0] + RotorThrustVector_[0];
           Vec3[1] = FreeStreamDirection_[1] + RotorThrustVector_[1];
@@ -1882,7 +1882,7 @@ void VORTEX_TRAIL::SmoothVelocity(VSPAERO_DOUBLE *Velocity)
     c[NumberOfNodes] =  0.;
     d[NumberOfNodes] =  r[NumberOfNodes];   
 
-    // General node... implicity smoothing
+    // General node... implicitly smoothing
 
     Eps = 0.5;
 
@@ -2072,7 +2072,7 @@ void VORTEX_TRAIL::SmoothWake(void)
        c_[NumberOfNodes] =  0.;
        d_[NumberOfNodes] =  r_[NumberOfNodes];   
 
-       // General node... implicity smoothing
+       // General node... implicitly smoothing
 
        Eps = 0.25;
 

--- a/src/vsp_aero/Solver/matrix.C
+++ b/src/vsp_aero/Solver/matrix.C
@@ -523,7 +523,7 @@ MATRIX operator/(const MATRIX &mat1, const MATRIX &mat2)
 
 #endif
 
-    // Find LU decompostion of mat2
+    // Find LU decomposition of mat2
 
     A.LU();
 
@@ -588,7 +588,7 @@ void MatDivMat(const MATRIX &mat1, const MATRIX &mat2, MATRIX &B)
 
 #endif
 
-    // Find LU decompostion of mat2
+    // Find LU decomposition of mat2
 
     A.LU();
 
@@ -917,7 +917,7 @@ MATRIX MATRIX::inverse(void)
 
 #endif
 
-    // Find LU decompostion of A
+    // Find LU decomposition of A
 
     A_inv.LU();
 
@@ -979,7 +979,7 @@ void MATRIX::inverse(MATRIX &A_inv, MATRIX &B)
 
 #endif
 
-    // Find LU decompostion of A
+    // Find LU decomposition of A
 
     A_inv.LU();
 
@@ -1297,7 +1297,7 @@ void MATRIX::solve_vdk(MATRIX &vec)
     VSPAERO_DOUBLE sum;
     MATRIX A_inv(*this);
 
-    // Find LU decompostion of A
+    // Find LU decomposition of A
 
     neq = A_inv.row;
 

--- a/src/vsp_aero/Solver/utils.H
+++ b/src/vsp_aero/Solver/utils.H
@@ -132,7 +132,7 @@ int asearch(VSPAERO_DOUBLE value, const VSPAERO_DOUBLE * array, int dim, VSPAERO
 
 int Intersect2DLines(VSPAERO_DOUBLE *u, VSPAERO_DOUBLE *v, VSPAERO_DOUBLE *p, VSPAERO_DOUBLE *q, VSPAERO_DOUBLE Epsilson);
 
-/** Check if a point p is withing a 2D tri defined by points x and y **/
+/** Check if a point p is within a 2D tri defined by points x and y **/
 
 int CheckIfInsideTri(VSPAERO_DOUBLE *x, VSPAERO_DOUBLE *y, VSPAERO_DOUBLE *p, VSPAERO_DOUBLE Eps);
 

--- a/src/vsp_aero/Solver/vspaero.C
+++ b/src/vsp_aero/Solver/vspaero.C
@@ -103,7 +103,7 @@ VSPAERO_DOUBLE RotationalRate_pList_[MAXRUNCASES];
 VSPAERO_DOUBLE RotationalRate_qList_[MAXRUNCASES];
 VSPAERO_DOUBLE RotationalRate_rList_[MAXRUNCASES];
 
-// Deltas for calculating derivaties
+// Deltas for calculating derivatives
 
 VSPAERO_DOUBLE Delta_AoA_;
 VSPAERO_DOUBLE Delta_Beta_;
@@ -490,7 +490,7 @@ void PrintUsageHelp()
        PRINTF(" -noise -steady                     Output steady state data to psu-wopwop, default is unsteady, periodic. \n");
        PRINTF(" -noise -english                    Assumes your model is in english (feet) units, will convert to SI for psu-wopwop \n");
        PRINTF(" -noise -flyby                      Set up flyby analysis for psu-wopwop \n");
-       PRINTF(" -noise -footprint                  Set up fot print analysis for psu-wopwop \n");
+       PRINTF(" -noise -footprint                  Set up footprint analysis for psu-wopwop \n");
        PRINTF("\n");                                                   
        PRINTF(" -opt -optfunction <#>              This is an optimization solve... solve the Aero equations and write out all information needed for adjoint solver. \n"); 
        PRINTF(" -opt -adjoint   -optfunction <#>   This is an optimization solve... solve Adjoint equations for optfunction #. Only used with the ADJOINT solver. \n");
@@ -510,9 +510,9 @@ void PrintUsageHelp()
        PRINTF("     -aoa  <A> END                  Angle of attack. A is a space delimited list of aoa values.\n");
        PRINTF("     -beta <B> END                  Sideslip angle. B is a space delimited list of beta values.\n");
        PRINTF("     -wakeiters <N>                 Number of wake iterations to calculate.\n");
-       PRINTF("     -symx                          Symetry flag - vehicle is symetric at x=0.\n");
-       PRINTF("     -symy                          Symetry flag - vehicle is symetric at y=0 (this is the most common).\n");
-       PRINTF("     -symz                          Symetry flag - vehicle is symetric at z=0.\n");
+       PRINTF("     -symx                          Symmetry flag - vehicle is symmetric at x=0.\n");
+       PRINTF("     -symy                          Symmetry flag - vehicle is symmetric at y=0 (this is the most common).\n");
+       PRINTF("     -symz                          Symmetry flag - vehicle is symmetric at z=0.\n");
        PRINTF("\n");
        PRINTF("EXAMPLES:\n");
        PRINTF("Example: Creating a setup file for testModel with mach and alpha sweep matrix\n");
@@ -862,11 +862,11 @@ void ParseInput(int argc, char *argv[])
                 
              }             
 
-             // Check if we are to do foot print
+             // Check if we are to do footprint
    
              if ( strcmp(argv[i+1],"-footprint") == 0 ) {
                 
-                PRINTF("Doing foot print noise analysis. \n");
+                PRINTF("Doing footprint noise analysis. \n");
                 
                 VSP_VLM().DoWopWopFootPrint();
                 

--- a/src/vsp_aero/Solver/vspaero_opt.C
+++ b/src/vsp_aero/Solver/vspaero_opt.C
@@ -25,14 +25,14 @@ int TestCase_1(char *FileName); // Single, SCALAR, optimization function
 
 int TestCase_2(char *FileName); // 3 SCALAR optimization functions, 1 forward solve, 3 adjoint solves
 
-int TestCase_3(char *FileName); // UNSTEADY analysis... with a single scalar optimization function, with user supplied intitial gradient 
+int TestCase_3(char *FileName); // UNSTEADY analysis... with a single scalar optimization function, with user supplied initial gradient 
 
-int TestCase_4(char *FileName); // UNSTEADY analysis... with a single scalar optimization function, with user supplied intitial gradient 
+int TestCase_4(char *FileName); // UNSTEADY analysis... with a single scalar optimization function, with user supplied initial gradient 
 
-int TestCase_5(char *FileName); // Single VECTOR optimization function, with user supplied intitial gradient...
+int TestCase_5(char *FileName); // Single VECTOR optimization function, with user supplied initial gradient...
                                 // followed by a matrix-vector multiply, and an adjoint matrix-vector multiply
 
-int TestCase_6(char *FileName); // UNSTEADY analysis... with 3 VECTOR optimization functions, with user supplied intitial gradient 
+int TestCase_6(char *FileName); // UNSTEADY analysis... with 3 VECTOR optimization functions, with user supplied initial gradient 
 
 int TestCase_7(char *FileName); // Dead stupid optimization of a wing...
 
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
        
     }
     
-    // Single VECTOR optimization function, with user supplied intitial gradient 
+    // Single VECTOR optimization function, with user supplied initial gradient 
     
     else if ( TestCase == 3 ) {
        
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
        
     }  
 
-    // UNSTEADY analysis... with a single scalar optimization function, with user supplied intitial gradient 
+    // UNSTEADY analysis... with a single scalar optimization function, with user supplied initial gradient 
        
     else if ( TestCase == 4 ) {
        
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
        
     }
 
-    // Single VECTOR optimization function, with user supplied intitial gradient...
+    // Single VECTOR optimization function, with user supplied initial gradient...
     // followed by a matrix-vector multiply, and an adjoint matrix-vector multiply
 
     else if ( TestCase == 5 ) {
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
        
     }
     
-    // UNSTEADY analysis... with 3 VECTOR optimization functions, with user supplied intitial gradient 
+    // UNSTEADY analysis... with 3 VECTOR optimization functions, with user supplied initial gradient 
 
     else if ( TestCase == 6 ) {
        
@@ -383,7 +383,7 @@ int TestCase_2(char *FileName)
 #                                                                              #
 #                            TestCase_3                                        #
 #                                                                              #
-#   Single VECTOR optimization function, with user supplied intitial gradient  #
+#   Single VECTOR optimization function, with user supplied initial gradient  #
 #                                                                              #
 ##############################################################################*/
 
@@ -404,7 +404,7 @@ int TestCase_3(char *FileName)
     
     Optimizer.NumberOfOptimizationFunctions() = Case = 1;
     
-    Optimizer.OptimizationFunction(Case) = OPT_WING_CL_TOTAL; // xyz force coefficents vs span for wing 1
+    Optimizer.OptimizationFunction(Case) = OPT_WING_CL_TOTAL; // xyz force coefficients vs span for wing 1
     
     Optimizer.OptimizationSet(Case) = Wing = 1; // We have to specify which wing this is
 
@@ -508,7 +508,7 @@ int TestCase_3(char *FileName)
 #                            TestCase_4                                        #
 #                                                                              #
 #   UNSTEADY analysis... with a single scalar optimization function, with      #
-#   user supplied intitial gradient                                            #
+#   user supplied initial gradient                                            #
 #                                                                              #
 ##############################################################################*/
 
@@ -669,7 +669,7 @@ int TestCase_4(char *FileName)
 #                                                                              #
 #                            TestCase_5                                        #
 #                                                                              #
-# Single vector optimization functions, with user supplied intitial gradient.. #
+# Single vector optimization functions, with user supplied initial gradient.. #
 # followed by a matrix-vector multiply, and an adjoint matrix-vector multiply  #
 #                                                                              #
 ##############################################################################*/
@@ -693,7 +693,7 @@ int TestCase_5(char *FileName)
     
     Case = 1;
     
-    Optimizer.OptimizationFunction(Case) = OPT_WING_CX_TOTAL; // xyz force coefficents vs span for wing 1
+    Optimizer.OptimizationFunction(Case) = OPT_WING_CX_TOTAL; // xyz force coefficients vs span for wing 1
     
     Optimizer.OptimizationSet(Case) = Wing = 1; // We have to specify which wing this is
 
@@ -767,7 +767,7 @@ int TestCase_5(char *FileName)
 #                            TestCase_6                                        #
 #                                                                              #
 # UNSTEADY analysis... with 3 VECTOR optimization functions with user supplied #
-# intitial gradient                                                            #                  
+# initial gradient                                                            #                  
 #                                                                              #
 ##############################################################################*/
 

--- a/src/vsp_aero/StandAlone/stb/stb_image.h
+++ b/src/vsp_aero/StandAlone/stb/stb_image.h
@@ -4662,13 +4662,13 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
 
    // we make a separate pass to expand bits to pixels; for performance,
    // this could run two scanlines behind the above code, so it won't
-   // intefere with filtering but will still be in the cache.
+   // interfere with filtering but will still be in the cache.
    if (depth < 8) {
       for (j=0; j < y; ++j) {
          stbi_uc *cur = a->out + stride*j;
          stbi_uc *in  = a->out + stride*j + x*out_n - img_width_bytes;
          // unpack 1/2/4-bit into a 8-bit buffer. allows us to keep the common 8-bit path optimal at minimal cost for 1/2/4-bit
-         // png guarante byte alignment, if width is not multiple of 8/4/2 we'll decode dummy trailing data that will be skipped in the later loop
+         // png guaranteed byte alignment, if width is not multiple of 8/4/2 we'll decode dummy trailing data that will be skipped in the later loop
          stbi_uc scale = (color == 0) ? stbi__depth_scale_table[depth] : 1; // scale grayscale values to 0..255 range
 
          // note that the final byte might overshoot and write more data than desired.
@@ -4850,7 +4850,7 @@ static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int
    p = (stbi_uc *) stbi__malloc_mad2(pixel_count, pal_img_n, 0);
    if (p == NULL) return stbi__err("outofmem", "Out of memory");
 
-   // between here and free(out) below, exitting would leak
+   // between here and free(out) below, exiting would leak
    temp_out = p;
 
    if (pal_img_n == 3) {
@@ -5720,7 +5720,7 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
    if (tga_height > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
    if (tga_width > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
 
-   //   do a tiny bit of precessing
+   //   do a tiny bit of processing
    if ( tga_image_type >= 8 )
    {
       tga_image_type -= 8;
@@ -6649,7 +6649,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
          // 0:  not specified.
       }
 
-      // background is what out is after the undoing of the previou frame;
+      // background is what out is after the undoing of the previous frame;
       memcpy( g->background, g->out, 4 * g->w * g->h );
    }
 
@@ -7639,7 +7639,7 @@ STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user
       1.31  (2011-06-20)
               a few more leak fixes, bug in PNG handling (SpartanJ)
       1.30  (2011-06-11)
-              added ability to load files via callbacks to accomidate custom input streams (Ben Wenger)
+              added ability to load files via callbacks to accommodate custom input streams (Ben Wenger)
               removed deprecated format-specific test/load functions
               removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks anyway
               error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha)

--- a/src/vsp_aero/TestCases/Rotor/README
+++ b/src/vsp_aero/TestCases/Rotor/README
@@ -6,7 +6,7 @@ Run the TestiT script
 
 ./Testit
 
-this will run vpsaero, and vpsaero_adjoint with the ouput of prop.gradient
+this will run vpsaero, and vpsaero_adjoint with the output of prop.gradient
 
 
 

--- a/src/vsp_aero/TestCases/Wing/README
+++ b/src/vsp_aero/TestCases/Wing/README
@@ -6,7 +6,7 @@ Run the TestiT script
 
 ./Testit
 
-this will run vpsaero, and vpsaero_adjoint with the ouput of hershey.gradient
+this will run vpsaero, and vpsaero_adjoint with the output of hershey.gradient
 
 
 

--- a/src/vsp_aero/Viewer/FEM_Node.H
+++ b/src/vsp_aero/Viewer/FEM_Node.H
@@ -48,7 +48,7 @@ public:
     
     void SizeList(int NumberOfFEMNodes);
 
-    // Accesss to node data
+    // Access to node data
     
     int NumberOfFEMNodes(void) { return NumberOfFEMNodes_; };
 

--- a/src/vsp_aero/Viewer/Optimization_Node.H
+++ b/src/vsp_aero/Viewer/Optimization_Node.H
@@ -44,7 +44,7 @@ public:
     
     void SizeList(int NumberOfFEMNodes);
 
-    // Accesss to node data
+    // Access to node data
     
     int NumberOfOptNodes(void) { return NumberOfOptNodes_; };
 

--- a/src/vsp_aero/Viewer/VSP_DegenGeom.C
+++ b/src/vsp_aero/Viewer/VSP_DegenGeom.C
@@ -329,7 +329,7 @@ void VSP_DEGEN_GEOM::WriteMeshFile(char *FileName)
 
     }
     
-    // Write out coded id to allow us to determine endiannes of files
+    // Write out coded id to allow us to determine endianness of files
 
     DumInt = -123789456; // Version 1 of the ADB file
 

--- a/src/vsp_aero/Viewer/VSP_Edge.H
+++ b/src/vsp_aero/Viewer/VSP_Edge.H
@@ -64,7 +64,7 @@ public:
     VSP_EDGE(const VSP_EDGE &VSPEdge);
     VSP_EDGE& operator=(const VSP_EDGE &VSPEdge);
 
-    // Accesss to tri data
+    // Access to tri data
 
     int &Node1(void) { return Node1_; };
     int &Node2(void) { return Node2_; };

--- a/src/vsp_aero/Viewer/VSP_Node.H
+++ b/src/vsp_aero/Viewer/VSP_Node.H
@@ -47,7 +47,7 @@ public:
     VSP_NODE(const VSP_NODE &VSPNode);
     VSP_NODE& operator=(const VSP_NODE &VSPNode);
 
-    // Accesss to node data
+    // Access to node data
 
     double &x(void) { return x_; };
     double &y(void) { return y_; };

--- a/src/vsp_aero/Viewer/VSP_Tris.H
+++ b/src/vsp_aero/Viewer/VSP_Tris.H
@@ -91,7 +91,7 @@ public:
     VSP_TRIS(const VSP_TRIS &VSPTri);
     VSP_TRIS& operator=(const VSP_TRIS &VSPTri);
 
-    // Accesss to tri data
+    // Access to tri data
 
     int &Node1(void) { return Node1_; };
     int &Node2(void) { return Node2_; };

--- a/src/vsp_aero/Viewer/glf.C
+++ b/src/vsp_aero/Viewer/glf.C
@@ -1512,7 +1512,7 @@ int glfLoadBMFFont(char *FName)
 			flag = 1;
 			break;
 		}
-	if (!flag) /* Not enought space for new texture */
+	if (!flag) /* Not enough space for new texture */
 	{
 		fclose(f);
 		free(texture);

--- a/src/vsp_aero/Viewer/glviewer.C
+++ b/src/vsp_aero/Viewer/glviewer.C
@@ -588,7 +588,7 @@ void GL_VIEWER::LoadMeshData(int ReLoad)
        
     }
 
-    // Read in the default in to check on endianess
+    // Read in the default in to check on endianness
 
     BIO.fread(&DumInt, i_size, 1, adb_file);
 
@@ -1043,7 +1043,7 @@ void GL_VIEWER::LoadMeshData(int ReLoad)
        
     } 
     
-    // Mark nodes on intitial mesh per the surface they are on... yes the
+    // Mark nodes on initial mesh per the surface they are on... yes the
     // solution is not unique at intersections... deal with it
     
     for ( i = 1 ; i <= NumberOfTris ; i++ ) {
@@ -1527,7 +1527,7 @@ void GL_VIEWER::LoadCalculixINPFile(void)
 
     sprintf(file_name_w_ext,"%s.inp",CalculixFileName);
 
-    printf("Attemping to open the Calculix inp file... \n");
+    printf("Attempting to open the Calculix inp file... \n");
 
     if ( (CalculixFile = fopen(file_name_w_ext,"r")) != NULL ) {
    
@@ -2354,7 +2354,7 @@ void GL_VIEWER::LoadCalculixDATFile(void)
 
     sprintf(file_name_w_ext,"%s.dat",CalculixFileName);
 
-    printf("Attemping to open the Calculix dat file... \n");
+    printf("Attempting to open the Calculix dat file... \n");
 
     if ( (CalculixFile = fopen(file_name_w_ext,"r")) != NULL ) {
 
@@ -2448,7 +2448,7 @@ void GL_VIEWER::LoadCalculixFRDFileOld(void)
 
     // Open the calculix solution file
     
-    printf("Attemping to open the Calculix frd file... \n");
+    printf("Attempting to open the Calculix frd file... \n");
 
     sprintf(file_name_w_ext,"%s.frd",CalculixFileName);
     
@@ -2969,7 +2969,7 @@ void GL_VIEWER::LoadCalculixFRDFile(void)
 
     // Open the calculix solution file
     
-    printf("Attemping to open the Calculix frd file... \n");
+    printf("Attempting to open the Calculix frd file... \n");
 
     sprintf(file_name_w_ext,"%s.frd",CalculixFileName);
     
@@ -6149,7 +6149,7 @@ void GL_VIEWER::LoadExistingSolutionData(int Case)
 
     } 
 
-    // Read in the default text string to check on endianess
+    // Read in the default text string to check on endianness
 
     BIO.fread(&DumInt, i_size, 1, adb_file);
 

--- a/src/vsp_aero/Viewer/stb_image.h
+++ b/src/vsp_aero/Viewer/stb_image.h
@@ -4520,13 +4520,13 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
 
    // we make a separate pass to expand bits to pixels; for performance,
    // this could run two scanlines behind the above code, so it won't
-   // intefere with filtering but will still be in the cache.
+   // interfere with filtering but will still be in the cache.
    if (depth < 8) {
       for (j=0; j < y; ++j) {
          stbi_uc *cur = a->out + stride*j;
          stbi_uc *in  = a->out + stride*j + x*out_n - img_width_bytes;
          // unpack 1/2/4-bit into a 8-bit buffer. allows us to keep the common 8-bit path optimal at minimal cost for 1/2/4-bit
-         // png guarante byte alignment, if width is not multiple of 8/4/2 we'll decode dummy trailing data that will be skipped in the later loop
+         // png guaranteed byte alignment, if width is not multiple of 8/4/2 we'll decode dummy trailing data that will be skipped in the later loop
          stbi_uc scale = (color == 0) ? stbi__depth_scale_table[depth] : 1; // scale grayscale values to 0..255 range
 
          // note that the final byte might overshoot and write more data than desired.
@@ -4708,7 +4708,7 @@ static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int
    p = (stbi_uc *) stbi__malloc_mad2(pixel_count, pal_img_n, 0);
    if (p == NULL) return stbi__err("outofmem", "Out of memory");
 
-   // between here and free(out) below, exitting would leak
+   // between here and free(out) below, exiting would leak
    temp_out = p;
 
    if (pal_img_n == 3) {
@@ -5554,7 +5554,7 @@ static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req
    STBI_NOTUSED(tga_x_origin); // @TODO
    STBI_NOTUSED(tga_y_origin); // @TODO
 
-   //   do a tiny bit of precessing
+   //   do a tiny bit of processing
    if ( tga_image_type >= 8 )
    {
       tga_image_type -= 8;
@@ -6468,7 +6468,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
          // 0:  not specified.
       }
 
-      // background is what out is after the undoing of the previou frame; 
+      // background is what out is after the undoing of the previous frame; 
       memcpy( g->background, g->out, 4 * g->w * g->h ); 
    }
 
@@ -7436,7 +7436,7 @@ STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user
       1.31  (2011-06-20)
               a few more leak fixes, bug in PNG handling (SpartanJ)
       1.30  (2011-06-11)
-              added ability to load files via callbacks to accomidate custom input streams (Ben Wenger)
+              added ability to load files via callbacks to accommodate custom input streams (Ben Wenger)
               removed deprecated format-specific test/load functions
               removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks anyway
               error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha)

--- a/src/vsp_aero/vspaero/problems/steady.py
+++ b/src/vsp_aero/vspaero/problems/steady.py
@@ -71,7 +71,7 @@ class SteadyProblem(BaseProblem):
         eval_funcs : iterable object containing strings.
             If not none, use these functions to evaluate.
         ignore_missing : bool
-            Flag to supress checking for a valid function. Please use
+            Flag to suppress checking for a valid function. Please use
             this option with caution.
 
         Examples
@@ -107,7 +107,7 @@ class SteadyProblem(BaseProblem):
         This is the main routine for returning useful (sensitivity)
         information from problem. The derivatives of the functions
         corresponding to the strings in EVAL_FUNCS are evaluated and
-        updated into the provided dictionary. The derivitives with
+        updated into the provided dictionary. The derivatives with
         respect to all design variables and node locations are computed.
 
         Parameters

--- a/src/vsp_aero/vspaero/utilities.py
+++ b/src/vsp_aero/vspaero/utilities.py
@@ -62,7 +62,7 @@ class BaseUI:
         """
 
         # Redefine the get_option def from the base class so we can
-        # mane sure the name is lowercase
+        # make sure the name is lowercase
 
         if name.lower() in self.default_options:
             return self.options[name.lower()][1]


### PR DESCRIPTION
Found via `codespell -q 3 -S ./.git,./src/external -L acount,ans,arry,ba,bu,cna,combind,defint,dum,finess,fo,fom,idel,inout,lod,momento,nam,numer,nwe,orgin,ot,parm,ptd,parms,pres,siz,statics,te,tesselate,tesselation,tey,uptodate,wit`
