### PR TITLE
Correct typo in degenGeom formatting when writing out

### DIFF
--- a/src/geom_core/DegenGeom.cpp
+++ b/src/geom_core/DegenGeom.cpp
@@ -967,7 +967,7 @@ void DegenGeom::write_degenGeomPlateCsv_file( FILE* file_id, int nxsecs, DegenPl
     {
         for ( int j = 0; j < ( num_pnts + 1 ) / 2; j++ )
         {
-            fprintf( file_id, makeCsvFmt( 11 ).c_str(),    \
+            fprintf( file_id, makeCsvFmt( 14 ).c_str(),    \
                      degenPlate.x[i][j].x(),             \
                      degenPlate.x[i][j].y(),             \
                      degenPlate.x[i][j].z(),             \


### PR DESCRIPTION
A minor typo in the number of fields input to the formatting function for the Plate degenGeom type causes 3 fields to be ignored when writing the degenGeom file.

This PR addresses the issue referenced in #264 by correcting the number of fields from 11 to 14.