### PR TITLE
Allow deleting many links at once.

### DIFF
--- a/src/geom_core/LinkMgr.cpp
+++ b/src/geom_core/LinkMgr.cpp
@@ -270,6 +270,24 @@ void LinkMgrSingleton::DelCurrLink()
     m_CurrLinkIndex = -1;
 }
 
+void LinkMgrSingleton::DelLinks(set<int> toDel)
+{
+    deque<Link *> keep;
+    for (int i = 0; i < (int)m_LinkVec.size() ; i++) {
+        if (toDel.count(i) == 0) {
+            keep.push_back(m_LinkVec[i]);
+        } else {
+            delete m_LinkVec[i];
+        }
+    }
+    m_LinkVec.clear();
+    for (int i = 0; i < (int)keep.size() ; i++) {
+        m_LinkVec.push_back(keep[i]);
+    }
+    keep.clear();
+    m_CurrLinkIndex = -1;
+}
+
 //==== Delete All Links ====//
 void LinkMgrSingleton::DelAllLinks()
 {

--- a/src/geom_core/LinkMgr.h
+++ b/src/geom_core/LinkMgr.h
@@ -14,10 +14,11 @@
 #include "Link.h"
 #include "UserParmContainer.h"
 #include <deque>
+#include <set>
 using std::string;
 using std::vector;
 using std::deque;
-
+using std::set;
 
 //==== Parm Link Manager ====//
 class LinkMgrSingleton
@@ -37,6 +38,7 @@ public:
 
     virtual bool AddCurrLink();                 // Add Link (A Copy of Working Link
     virtual void DelCurrLink();                 // Delete Currently Selected Link
+    virtual void DelLinks(const set<int>);
     virtual void DelAllLinks();
     virtual bool LinkAllComp();                 // Link All Parms in Selected Parm Containers
     virtual bool LinkAllGroup();                // Link All Parms in Selected Group
@@ -47,7 +49,7 @@ public:
     virtual bool AddLink( const string& pA, const string& pB, bool init_link_parms = true );         // Link Two Parms
     virtual void AddLink( Link* link )                      {  m_LinkVec.push_back( link ); }
     virtual void ParmChanged( const string& pid, bool start_flag );     // A Parm Has Changed Check Links
-
+    
     virtual void SetCurrLinkIndex( int i )                  { m_CurrLinkIndex = i; }
     virtual int  GetCurrLinkIndex()                         { return m_CurrLinkIndex; }
     virtual Link* GetCurrLink();

--- a/src/gui_and_draw/ParmLinkScreen.cpp
+++ b/src/gui_and_draw/ParmLinkScreen.cpp
@@ -238,12 +238,9 @@ bool ParmLinkScreen::Update()
                  c_name_B.c_str(), g_name_B.c_str(), p_name_B.c_str() );
 
         m_LinkBrowser->add( str );
-    }
-
-    int index = LinkMgr.GetCurrLinkIndex();
-    if ( index >= 0 && index < num_links )
-    {
-        m_LinkBrowser->select( index + 2 );
+        if (selected.count(i) != 0) {
+            m_LinkBrowser->select(i+2);
+        }
     }
 
     m_LinkBrowser->hposition( h_pos );
@@ -261,8 +258,14 @@ void ParmLinkScreen::CallBack( Fl_Widget* w )
 
     if ( w == m_LinkBrowser )
     {
-        int sel = m_LinkBrowser->value();
-        LinkMgr.SetCurrLinkIndex( sel - 2 );
+        // build up the set of all selected links
+        selected.clear();
+        for (int i = 2; i <= m_LinkBrowser->size(); i++) {
+            if (m_LinkBrowser->selected(i)) {
+                selected.insert(i-2);
+                LinkMgr.SetCurrLinkIndex( i - 2 );
+            }
+        }
     }
     // Check that Parm is dropped on top of ParmPicker A
     else if ( w == ( m_ParmAGroup.GetGroup() ) && Fl::event_inside( w ) )
@@ -298,6 +301,7 @@ void ParmLinkScreen::GuiDeviceCallBack( GuiDevice* device )
     {
         LinkMgr.SetParm( true, m_ParmAPicker.GetParmChoice() );
         LinkMgr.SetParm( false, m_ParmBPicker.GetParmChoice() );
+        selected.clear();
         LinkMgr.SetCurrLinkIndex( -1 );
     }
     else if( device == &m_AddLink )
@@ -307,14 +311,21 @@ void ParmLinkScreen::GuiDeviceCallBack( GuiDevice* device )
         {
             fl_alert( "Error: Identical Parms or Already Linked" );
         }
+        selected.clear();
     }
     else if ( device == &m_DeleteLink )
     {
-        LinkMgr.DelCurrLink();
+        if (selected.size() > 1) {
+            LinkMgr.DelLinks(selected);            
+        } else {
+            LinkMgr.DelCurrLink();
+        }
+        selected.clear();
     }
     else if ( device == &m_DeleteAllLinks )
     {
         LinkMgr.DelAllLinks();
+        selected.clear();
     }
     else if ( device == &m_LinkConts )
     {
@@ -323,6 +334,7 @@ void ParmLinkScreen::GuiDeviceCallBack( GuiDevice* device )
         {
             fl_alert( "Error: Identical Comps" );
         }
+        selected.clear();
     }
     else if ( device == &m_LinkGroups )
     {
@@ -331,6 +343,7 @@ void ParmLinkScreen::GuiDeviceCallBack( GuiDevice* device )
         {
             fl_alert( "Error: Identical Group" );
         }
+        selected.clear();
     }
     else if ( device == &m_OffsetTog )
     {
@@ -408,10 +421,12 @@ void ParmLinkScreen::GuiDeviceCallBack( GuiDevice* device )
     else if ( device == &m_ASort )
     {
         LinkMgr.SortLinksByA();
+        selected.clear();
     }
     else if ( device == &m_BSort )
     {
         LinkMgr.SortLinksByB();
+        selected.clear();
     }
 
     m_ScreenMgr->SetUpdateFlag( true );

--- a/src/gui_and_draw/ParmLinkScreen.h
+++ b/src/gui_and_draw/ParmLinkScreen.h
@@ -63,5 +63,7 @@ protected:
     SliderAdjRangeInput m_UpperLimitSlider;
 
     ColResizeBrowser* m_LinkBrowser;
+private:
+    set<int> selected;
 };
 #endif


### PR DESCRIPTION
This is a small hack that makes multi-select and delete work.

The idea was to go all the way to allow multi-select and parameter editing to work, but the singleton LinkMgr is a bit too complex for me to get into hacking today, so this will have to be good enough.

It would have been enough to solve the problem we had (a model with lots of auto-generated links that we mostly didn't want, but wanted to keep a lot of them, too). We ended up solving it another way.