### PR TITLE
[utils] Fix error in k2degF fxn

### DIFF
--- a/src/python_api/packages/utilities/utilities/units.py
+++ b/src/python_api/packages/utilities/utilities/units.py
@@ -279,7 +279,7 @@ def degF2r(f):
 
 
 def k2degF(k):
-    return degF2r(k2r * k)
+    return r2degF(k2r * k)
 
 
 def degF2degC(f):


### PR DESCRIPTION
Noticed a small error in the Python API unit conversion utility file. When converting from Kelvin to Fahrenheit, the function was converting Kelvin to Rankine, and then running that through the degF2r function and returning that. I switched the return statement line so that it converts from Kelvin to Rankine, then uses the r2degF function to return Fahrenheit as expected.