### PR TITLE
Fix VSP icon not showing in Ubuntu sidebar

### DIFF
--- a/src/cmake/postinst
+++ b/src/cmake/postinst
@@ -20,6 +20,7 @@ Exec=/usr/local/bin/vsp %u
 Terminal=false
 Categories=Education;Science;Physics;Engineering;
 Keywords=airfoil;aircraft;model;design;
+StartupWMClass=FLTK
 EOL
 chmod +x /usr/share/applications/vsp.desktop;
 desktop-file-install /usr/share/applications/vsp.desktop;


### PR DESCRIPTION
OpenVSP's icon does not show on the Linux side bar when open. Instead it shows up as a 'generic application' gear icon.
The fix was to add the field `StartupWMClass=FLTK` to the vsp.desktop file.

Refer StackOverflow [thread](https://askubuntu.com/questions/558098/icon-missing-when-application-is-launched?rq=1) for reason on the issue. 