### PR TITLE
Fix various typos in the codebase

### DIFF
--- a/src/APIReadme.md.in
+++ b/src/APIReadme.md.in
@@ -72,7 +72,7 @@ will include the *.vsppart code in the *.vsp3 file.
 ### Python API Instructions
 View the **README** file in the **python** directory of the distribution for instructions on Python API installation. Note, the Python
 version must be the same as what OpenVSP was compiled with. For instance OpenVSP 3.21.2 Win64 requires Python 3.6-x64. If a different
-verison of Python is desired, the user must compile OpenVSP themselves.
+version of Python is desired, the user must compile OpenVSP themselves.
 
 ### MATLAB API
 The MATLAB API template (matlab_api) is included with the OpenVSP source code, but not the distributed binaries. This is because it requires

--- a/src/cfd_mesh/CfdMeshMgr.cpp
+++ b/src/cfd_mesh/CfdMeshMgr.cpp
@@ -183,7 +183,7 @@ void CfdMeshMgrSingleton::CleanUp()
     SurfaceIntersectionSingleton::CleanUp();
 
     int i;
-    //==== Delete Stored Ndoes ====//
+    //==== Delete Stored Nodes ====//
     for ( i = 0 ; i < ( int )m_nodeStore.size() ; i++ )
     {
         delete m_nodeStore[i];
@@ -2691,7 +2691,7 @@ void CfdMeshMgrSingleton::MergeBorderEndPoints()
     // However, it currently is simply compared to the distance between groups.
     // Consequently, while a reasonable value was previously 1e-2, a much smaller value is now appropriate.
     // In addition, this tolerance is actually in terms of r^2.
-    // This would be better if we had a better representative minimum feature length that was the mininum of:
+    // This would be better if we had a better representative minimum feature length that was the minimum of:
     //     Grid minimum edge length
     //     Shortest edge length specified in any source
     //     Shortest length of any boundary

--- a/src/cfd_mesh/CfdMeshMgr.h
+++ b/src/cfd_mesh/CfdMeshMgr.h
@@ -34,7 +34,7 @@
 //
 //      CfdMeshMgr::IntersectSplitChains: Intersect non-border chains and split.
 //
-//  InitMesh: Tesselate chaings, merge border end points, build initial mesh, remove interior tris.
+//  InitMesh: Tesselate chains, merge border end points, build initial mesh, remove interior tris.
 //
 //      CfdMeshMgr::TessellateChains: Teseslate all chains based on grid density
 //

--- a/src/cfd_mesh/Mesh.cpp
+++ b/src/cfd_mesh/Mesh.cpp
@@ -1758,7 +1758,7 @@ void Mesh::InitMesh( vector< vec2d > & uw_points, vector< MeshSeg > & segs_index
         cnt++;
     }
 
-    //==== Constrained Delaunay Trianglulation ====//
+    //==== Constrained Delaunay Triangulation ====//
     double est_num_tris = ( uw_prime.size() / 4 ) * ( uw_prime.size() / 4 );
     if ( est_num_tris < 1 )
     {
@@ -1787,7 +1787,7 @@ void Mesh::InitMesh( vector< vec2d > & uw_points, vector< MeshSeg > & segs_index
 
     snprintf( str, sizeof( str ), "zpYYQa%8.6fq20", uw_tri_area );
 
-    //==== Constrained Delaunay Trianglulation ====//
+    //==== Constrained Delaunay Triangulation ====//
     tristatus = triangle_context_options( ctx, str );
     if ( tristatus != TRI_OK ) printf( "triangle_context_options Error\n" );
 

--- a/src/cfd_mesh/Surf.cpp
+++ b/src/cfd_mesh/Surf.cpp
@@ -222,7 +222,7 @@ void Surf::BuildTargetMap( vector< MapSource* > &sources, int sid )
                 // Assign MIN_LEN_CONSTRAINT, MIN_LEN_CONSTRAINT_CURV_GAP, MIN_LEN_CONSTRAINT_CURV_NCIRCSEG as appropriate.
                 reason += vsp::MIN_LEN_INCREMENT;
 
-                if ( reason >= vsp::NUM_MESH_REASON ) // Should be imposible, just as a safety check.
+                if ( reason >= vsp::NUM_MESH_REASON ) // Should be impossible, just as a safety check.
                 {
                     reason = vsp::MIN_LEN_CONSTRAINT;
                 }

--- a/src/cfd_mesh/SurfaceIntersectionMgr.h
+++ b/src/cfd_mesh/SurfaceIntersectionMgr.h
@@ -34,7 +34,7 @@
 //
 //      CfdMeshMgr::IntersectSplitChains: Intersect non-border chains and split.
 //
-//  InitMesh: Tesselate chaings, merge border end points, build initial mesh, remove interior tris.
+//  InitMesh: Tesselate chains, merge border end points, build initial mesh, remove interior tris.
 //
 //      CfdMeshMgr::MergeBorderEndPoints: Merge IPnts into single points.
 //

--- a/src/geom_api/APIDefines.h
+++ b/src/geom_api/APIDefines.h
@@ -732,7 +732,7 @@ enum FREESTREAM_PD_UNITS { PD_UNITS_IMPERIAL = 0,	/*!< Imperial unit system */
 /*!
 	\ingroup Enumerations
 */
-/*! Enum for setting the mode ofthe file chooser. */
+/*! Enum for setting the mode of the file chooser. */
 enum FILE_CHOOSER_MODE { OPEN,	/*!< Browse files that already exist */
                          SAVE,	/*!< Browse file system and enter file name */
                          NUM_FILE_CHOOSER_MODES	/*!< Number of file chooser modes */

--- a/src/geom_api/VSP_Geom_API.h
+++ b/src/geom_api/VSP_Geom_API.h
@@ -3391,7 +3391,7 @@ extern void SetShowBorders( bool brdr );
     \ingroup Visualization
 */
 /*!
-    Set the draw type of the specified goemetry
+    Set the draw type of the specified geometry
     \forcpponly
     \code{.cpp}
     string pid = AddGeom( "POD", "" );                             // Add Pod for testing
@@ -3418,7 +3418,7 @@ extern void SetGeomDrawType(const string &geom_id, int type);
     \ingroup Visualization
 */
 /*!
-    Set the wireframe color of the specified goemetry
+    Set the wireframe color of the specified geometry
     \forcpponly
     \code{.cpp}
     string pid = AddGeom( "POD", "" );
@@ -3446,7 +3446,7 @@ extern void SetGeomWireColor( const string &geom_id, int r, int g, int b );
     \ingroup Visualization
 */
 /*!
-    Set the display type of the specified goemetry
+    Set the display type of the specified geometry
     \forcpponly
     \code{.cpp}
     string pid = AddGeom( "POD" );                             // Add Pod for testing
@@ -3473,7 +3473,7 @@ extern void SetGeomDisplayType(const string &geom_id, int type);
     \ingroup Visualization
 */
 /*!
-    Set the visualization material the specified goemetry
+    Set the visualization material the specified geometry
     \forcpponly
     \code{.cpp}
     string pid = AddGeom( "POD" );
@@ -3498,7 +3498,7 @@ extern void SetGeomMaterialName( const string &geom_id, const string &name );
     \ingroup Visualization
 */
 /*!
-    Set the visualization material the specified goemetry
+    Set the visualization material the specified geometry
     \forcpponly
     \code{.cpp}
     string pid = AddGeom( "POD" );
@@ -3518,10 +3518,10 @@ extern void SetGeomMaterialName( const string &geom_id, const string &name );
     \endcode
     \endPythonOnly
     \param [in] name string Material name
-    \param [in] ambient vec3d Ambient color RGB tripple on scale [0, 255]
-    \param [in] diffuse vec3d Diffuse color RGB tripple on scale [0, 255]
-    \param [in] specular vec3d Specular color RGB tripple on scale [0, 255]
-    \param [in] emmissive vec3d Emissive color RGB tripple on scale [0, 255]
+    \param [in] ambient vec3d Ambient color RGB triple on scale [0, 255]
+    \param [in] diffuse vec3d Diffuse color RGB triple on scale [0, 255]
+    \param [in] specular vec3d Specular color RGB triple on scale [0, 255]
+    \param [in] emmissive vec3d Emissive color RGB triple on scale [0, 255]
     \param [in] shininess double Shininess exponent on scale [0, 127]
     \param [in] alpha double Transparency factor on scale [0, 1]
 */

--- a/src/geom_core/ConformalGeom.cpp
+++ b/src/geom_core/ConformalGeom.cpp
@@ -933,7 +933,7 @@ void ConformalGeom::UpdateParms( VspSurf & surf )
 
 // Possibly disable spanwise offset for wings.  As option.  Probably future work.
 // Someday add span fraction coordinate for wings (eta).  do when spanwise coordinate for control surfaces is done.
-// Posibly make U1 and U2 trimming separate options - if compatible means can be figured out.
+// Possibly make U1 and U2 trimming separate options - if compatible means can be figured out.
 
 //==== Trim In U Direction - Use Flat Cap ====//
 void ConformalGeom::TrimU( VspSurf & surf )

--- a/src/geom_core/Geom.cpp
+++ b/src/geom_core/Geom.cpp
@@ -2004,7 +2004,7 @@ void Geom::UpdateSymmAttach()
         m_TransMatVec[i].postMult( symmOriginMat.data() );
 
         m_FeaTransMatVec[i] = m_TransMatVec[i];
-        m_FeaTransMatVec[i].matMult( retrun_relTrans.data() ); // m_FeaTransMatVec does not inclde the relTrans matrix
+        m_FeaTransMatVec[i].matMult( retrun_relTrans.data() ); // m_FeaTransMatVec does not include the relTrans matrix
     }
 }
 

--- a/src/geom_core/HumanGeom.cpp
+++ b/src/geom_core/HumanGeom.cpp
@@ -879,7 +879,7 @@ void HumanGeom::UpdateSymmAttach()
         m_TransMatVec[i].postMult( symmOriginMat.data() );
         m_TransMatVec[i].xformvec( m_Verts[i] );     // Apply total transformation to meshes
         m_FeaTransMatVec[i] = m_TransMatVec[i];
-        m_FeaTransMatVec[i].matMult( retrun_relTrans.data() ); // m_FeaTransMatVec does not inclde the relTrans matrix
+        m_FeaTransMatVec[i].matMult( retrun_relTrans.data() ); // m_FeaTransMatVec does not include the relTrans matrix
     }
 
 }

--- a/src/geom_core/MeshGeom.cpp
+++ b/src/geom_core/MeshGeom.cpp
@@ -3549,7 +3549,7 @@ void MeshGeom::MassSlice( vector < DegenGeom > &degenGeom, bool degen, int numSl
             vol_vec.push_back( m_PointMassVec[ i ]->m_Vol );
         }
 
-        res->Add( NameValData( "Num_Comps", (int)name_vec.size(), "Number of componenets." ) );
+        res->Add( NameValData( "Num_Comps", (int)name_vec.size(), "Number of components." ) );
         res->Add( NameValData( "Comp_Name", name_vec, "Component names." ) );
         res->Add( NameValData( "Comp_ID", id_vec, "Component IDs." ) );
         res->Add( NameValData( "Comp_Mass", mass_vec, "Component contribution to mass." ) );
@@ -4252,7 +4252,7 @@ vector< string > MeshGeom::GetTMeshIDs()
         string plate;
         if ( m_TMeshVec[ i ]->m_PlateNum == -1 )
         {
-            // plate; // emtpy string.
+            // plate; // empty string.
         }
         else
         {

--- a/src/geom_core/ParasiteDragMgr.cpp
+++ b/src/geom_core/ParasiteDragMgr.cpp
@@ -3240,7 +3240,7 @@ string ParasiteDragMgrSingleton::ExportToCSV()
         res->Add( NameValData( "Comp_Roughness", new_geo_Roughness, "Surface roughness." ) );
         res->Add( NameValData( "Comp_TeTwRatio", new_geo_TeTwRatio, "Te/Tw temperature ratio." ) );
         res->Add( NameValData( "Comp_TawTwRatio", new_geo_TawTwRatio, "Taw/Tw temperature ratio." ) );
-        res->Add( NameValData( "Comp_Q", new_geo_Q, "Inteference factor." ) );
+        res->Add( NameValData( "Comp_Q", new_geo_Q, "Interference factor." ) );
         res->Add( NameValData( "Comp_f", new_geo_f, "Drag area." ) );
         res->Add( NameValData( "Comp_CD", new_geo_CD, "Drag coefficient." ) );
         res->Add( NameValData( "Comp_PercTotalCD", new_geo_percTotalCD, "Percent of total CD." ) );
@@ -3264,7 +3264,7 @@ string ParasiteDragMgrSingleton::ExportToCSV()
         res->Add( NameValData( "Comp_Roughness", m_geo_Roughness, "Surface roughness." ) );
         res->Add( NameValData( "Comp_TeTwRatio", m_geo_TeTwRatio, "Te/Tw temperature ratio." ) );
         res->Add( NameValData( "Comp_TawTwRatio", m_geo_TawTwRatio, "Taw/Tw temperature ratio." ) );
-        res->Add( NameValData( "Comp_Q", m_geo_Q, "Inteference factor." ) );
+        res->Add( NameValData( "Comp_Q", m_geo_Q, "Interference factor." ) );
         res->Add( NameValData( "Comp_f", m_geo_f, "Drag area." ) );
         res->Add( NameValData( "Comp_CD", m_geo_CD, "Drag coefficient." ) );
         res->Add( NameValData( "Comp_PercTotalCD", m_geo_percTotalCD, "Percent of total CD." ) );

--- a/src/geom_core/ProjectionMgr.cpp
+++ b/src/geom_core/ProjectionMgr.cpp
@@ -998,7 +998,7 @@ void ProjectionMgrSingleton::Triangulate_TRI( vector < vector < int > > &connlis
 
     char cmdline[] = "zpQ";
 
-    //==== Constrained Delaunay Trianglulation ====//
+    //==== Constrained Delaunay Triangulation ====//
     tristatus = triangle_context_options( ctx, cmdline );
     if ( tristatus != TRI_OK ) printf( "triangle_context_options Error\n" );
 

--- a/src/geom_core/TMesh.cpp
+++ b/src/geom_core/TMesh.cpp
@@ -2327,7 +2327,7 @@ void TTri::TriangulateSplit_TRI( int flattenAxis, const vector < vec3d > &ptvec,
         {
             char cmdline[] = "zpQ";
 
-            //==== Constrained Delaunay Trianglulation ====//
+            //==== Constrained Delaunay Triangulation ====//
             tristatus = triangle_context_options( ctx, cmdline );
             if ( tristatus != TRI_OK ) printf( "triangle_context_options Error\n" );
 

--- a/src/geom_core/Vehicle.cpp
+++ b/src/geom_core/Vehicle.cpp
@@ -4455,7 +4455,7 @@ void Vehicle::AddLinkableContainers( vector< string > & linkable_container_vec )
     StructureMgr.AddLinkableContainers( linkable_container_vec );
 }
 
-// As m_BBox, but wihtout EngineGeom modifications applied.
+// As m_BBox, but without EngineGeom modifications applied.
 BndBox Vehicle::UpdateOrigBBox( int set )
 {
     BndBox bbox;  // m_OrigBBox

--- a/src/geom_core/WaveDragMgr.cpp
+++ b/src/geom_core/WaveDragMgr.cpp
@@ -566,7 +566,7 @@ void WaveDragSingleton::FitBuildup()
 void WaveDragSingleton::PushSliceResults( Results* res )
 {
     //==== Add Mesh Results after component and subsurface intersection ====//
-    res->Add( NameValData( "Ambiguous_Subsurf_Flag", m_AmbigSubSurf, "Ambigious subsurface flag." ) );
+    res->Add( NameValData( "Ambiguous_Subsurf_Flag", m_AmbigSubSurf, "Ambiguous subsurface flag." ) );
 
     res->Add( NameValData( "Num_Slices", m_NSlice, "Number of slices." ) );
 

--- a/src/gui_and_draw/GuiDevice.cpp
+++ b/src/gui_and_draw/GuiDevice.cpp
@@ -2539,7 +2539,7 @@ void ColorPicker::DeviceCB( Fl_Widget* w )
 }
 
 //=====================================================================//
-//===========       Parmater Picker                         ===========//
+//===========       Parameter Picker                        ===========//
 //=====================================================================//
 ParmPicker::ParmPicker()
 {
@@ -2668,7 +2668,7 @@ vector< string > ParmPicker::FindParmNames( vector< string > & parm_id_vec )
 }
 
 //=====================================================================//
-//===========       Parmater Tree Picker                    ===========//
+//===========       Parameter Tree Picker                   ===========//
 //=====================================================================//
 ParmTreePicker::ParmTreePicker()
 {

--- a/src/gui_and_draw/GuiDevice.h
+++ b/src/gui_and_draw/GuiDevice.h
@@ -1282,7 +1282,7 @@ public:
     virtual void UpdateAxisLimits( vector< double > x_data, vector < double > y_data, bool mag_round = true );
 
     // Clear and reinitialize the parm sliders. Add G1 continuity check boxes for CEDIT. 
-    // This function must be called in the size of the curve parameter vectors chenges
+    // This function must be called in the size of the curve parameter vectors changes
     // and when a type conversion is performed
     virtual void RedrawXYSliders( int num_pts, int curve_type );
 

--- a/src/gui_and_draw/SelectFileScreen.cpp
+++ b/src/gui_and_draw/SelectFileScreen.cpp
@@ -268,7 +268,7 @@ void  SelectFileScreen::GuiDeviceCallBack(GuiDevice* device)
         m_FileName = m_FileSelectInput.GetString();
     }
 
-    //Tells m_ScreenMgr to exacute Update() function
+    //Tells m_ScreenMgr to execute Update() function
     m_ScreenMgr->SetUpdateFlag( true );
 }
 

--- a/src/gui_and_draw/SetEditorScreen.cpp
+++ b/src/gui_and_draw/SetEditorScreen.cpp
@@ -217,7 +217,7 @@ void SetEditorScreen::CloseCallBack( Fl_Widget *w )
 //==== Callbacks ====//
 
 //This Main Callback is responding to events for windows, groups, and widgets attached to this object.
-//m_ScreenMgr is another BasicScreen member inherated from VspScreen (included from "ScreenBase.h")
+//m_ScreenMgr is another BasicScreen member inherited from VspScreen (included from "ScreenBase.h")
 void SetEditorScreen::CallBack( Fl_Widget *w )
 {
     //We get a vehiclePtr to help work with events
@@ -320,7 +320,7 @@ void SetEditorScreen::GuiDeviceCallBack( GuiDevice* device )
         vehiclePtr->SetActiveGeomVec( activate_geom_vec );
     }
 
-    //Tells m_ScreenMgr to exacute Update() function
+    //Tells m_ScreenMgr to execute Update() function
     m_ScreenMgr->SetUpdateFlag( true );
 }
 

--- a/src/gui_and_draw/SubGLWindow.h
+++ b/src/gui_and_draw/SubGLWindow.h
@@ -17,7 +17,7 @@ class FuselageGeom;
 namespace VSPGUI
 {
 /*
-* This class provides all functionalites of a 2D opengl window.
+* This class provides all functionalities of a 2D opengl window.
 */
 class VspSubGlWindow : public Fl_Gl_Window
 {

--- a/src/help/AdvLink.md
+++ b/src/help/AdvLink.md
@@ -4,7 +4,7 @@ title:  'Advanced Parameter Linking'
 
 Advanced parameter linking allows the user to define mathematical relationships between arbitrary parameters.
 
-To create an advanced link, the user first add's a link and changes the name to something apropriate.
+To create an advanced link, the user first add's a link and changes the name to something appropriate.
 Next, the user identifies one or more input parameters and defines a variable name to be used as an alias for each.
 The user then identifies one or more output parameters and defines their aliases.  Finally, the user writes code to
 define how the output parameters depend on the inputs.

--- a/src/help/html/AdvLink.html
+++ b/src/help/html/AdvLink.html
@@ -95,7 +95,7 @@
 <p>Advanced parameter linking allows the user to define mathematical
 relationships between arbitrary parameters.</p>
 <p>To create an advanced link, the user first add's a link and changes
-the name to something apropriate. Next, the user identifies one or more
+the name to something appropriate. Next, the user identifies one or more
 input parameters and defines a variable name to be used as an alias for
 each. The user then identifies one or more output parameters and defines
 their aliases. Finally, the user writes code to define how the output

--- a/src/python_api/auto_facade.py
+++ b/src/python_api/auto_facade.py
@@ -72,7 +72,7 @@ def _exception_hook(exc_type, exc_value, tb):
     for line in exc_value.args[0].split("\n")[3:]:
         regular_traceback.append(line)
 
-    print("This error occured while using the facade API")
+    print("This error occurred while using the facade API")
     print("Facade Traceback:")
     for line in facade_traceback:
         print(line)
@@ -81,7 +81,7 @@ def _exception_hook(exc_type, exc_value, tb):
     for line in regular_traceback:
         print(line)
 
-# function to send and recieve data from the facade server
+# function to send and receive data from the facade server
 def _send_recieve(func_name, args, kwargs):
     b_data = pack_data([func_name, args, kwargs], True)
     sock.sendall(b_data)

--- a/src/python_api/packages/CHARM/charm/examples/simple_prop.py
+++ b/src/python_api/packages/CHARM/charm/examples/simple_prop.py
@@ -35,7 +35,7 @@ run_directory = "runs"
 overwrite_files = True
 
 vsp_filename = "prop.vsp3"
-# This is one of your problems.  This VSP3 model was made inconsitently...the set name in the model is "Charm", not
+# This is one of your problems.  This VSP3 model was made inconsistently...the set name in the model is "Charm", not
 # "CHARM."  
 vsp_charm_set_name = "Charm"
 # You don't need to have a pitch component name because this is a simple rotor, there is no Datum in the vsp3 model

--- a/src/python_api/packages/CHARM/charm/input_automation.py
+++ b/src/python_api/packages/CHARM/charm/input_automation.py
@@ -166,7 +166,7 @@ class CharmRotorSettings:
         :param icoll: set ICOLL variable in CHARM rotor wake file. Controls how collective is adjusted
         :param airfoil_r_o_Rs: optional array of local radius/blade radius locations of airfoil sections
             specified in `airfoil_opts`. If not specified, an attempt to use VSP will be made to locate the airfoils
-        :param nchord: number of chordwise elements in vortex latice method
+        :param nchord: number of chordwise elements in vortex lattice method
         :param icnvct: controls downstream wake convection; =0 is a free wake, =1 is free up fixed down, =2 is fixed
         :param flap_type: flap type input for segment ISEG; =0 no flap, =1 plain flap (nicolai), =-1 plain flap
         :param flap_defl: flap deflection of segment ISEG in degrees (0 - 40)
@@ -1464,7 +1464,7 @@ def build_default_trim_settings(trim_template=None) -> CharmTrimSettings:
     ctrl_expr = re.compile(r"(^|\s)Ctrl\s")
     init_expr = re.compile(r"(^|\s)Initial\s")
     line_cntrl_gains = 0  # Initialize variable
-    line_init_labels = 0  # Initiailize variable
+    line_init_labels = 0  # Initialize variable
     for linenum in range(len(trim_template)):
         line = trim_template[linenum]
         if re.search(ctrl_expr, line):
@@ -1967,7 +1967,7 @@ def build_charm_input_files(degen_mgr: dg.DegenGeomMgr, case_name,
     :return: dictionary of name, file contents pairs
     """
 
-    # Get key quantites from run characteristic file
+    # Get key quantities from run characteristic file
     run_char_vars = read_run_characteristics_template(template_filename=run_char_filename,
                                                       template_file=run_char_template)
     num_psi = run_char_vars['NPSI']

--- a/src/python_api/packages/PyVSP/pyvsp/analysis_panel.py
+++ b/src/python_api/packages/PyVSP/pyvsp/analysis_panel.py
@@ -92,7 +92,7 @@ class AnalysisPanel(wx.Panel):
         analysis_name = self.vsp.ListAnalysis()[analysis_index]
 
         # I don't think the has_defaults list was implemented
-        # I imagine it was suppposed to save user inputs
+        # I imagine it was supposed to save user inputs
         if not analysis_name in self.has_defaults_list:
             self.vsp.SetAnalysisInputDefaults(analysis_name)
             self.has_defaults_list.append(analysis_name)

--- a/src/python_api/packages/PyVSP/pyvsp/pyvsp.py
+++ b/src/python_api/packages/PyVSP/pyvsp/pyvsp.py
@@ -90,7 +90,7 @@ class DemoFrame(wx.Frame):
         self.vtk_panel_buffer_box.Add(self.vtkPanel, 1, wx.EXPAND|wx.ALL,5)
         self.vtk_panel_buffer.SetSizer(self.vtk_panel_buffer_box)
 
-        #creates the analyis panel
+        #creates the analysis panel
         self.analysis_panel = AnalysisPanel(top_splitter, vsp)
 
         #adds analysis panel and vtk panel
@@ -254,7 +254,7 @@ class DemoFrame(wx.Frame):
 
     def on_screenshot(self, event):
         """
-        Prompts user for save locaiton, then takes a screenshot
+        Prompts user for save location, then takes a screenshot
         It uses a default width/height of 400
         It uses a default trasperency flag of False
 

--- a/src/python_api/packages/openvsp/openvsp/index.rst
+++ b/src/python_api/packages/openvsp/openvsp/index.rst
@@ -22,7 +22,7 @@ Python API Instructions
 -----------------------
 View the **README** file in the **python** directory of the distribution for instructions on Python API installation. Note, the Python
 version must be the same as what OpenVSP was compiled with. For instance OpenVSP 3.21.2 Win64 requires Python 3.6-x64. If a different 
-verison of Python is desired, the user must compile OpenVSP themselves. 
+version of Python is desired, the user must compile OpenVSP themselves. 
 
  
 Improvements

--- a/src/python_api/packages/openvsp_config/openvsp_config/index.rst
+++ b/src/python_api/packages/openvsp_config/openvsp_config/index.rst
@@ -7,7 +7,7 @@ The OpenVSP python API can be loaded in different modes.  Since it is not possib
 package during import, :py:`openvsp_config` is a configuration module that holds variables that the :py:`openvsp` package
 uses to set how it is loaded.
 
-At present, the :py:`openvsp_config` has two attributes that controll how :py:`openvsp` is loaded, :py:`LOAD_GRAPHICS` and
+At present, the :py:`openvsp_config` has two attributes that control how :py:`openvsp` is loaded, :py:`LOAD_GRAPHICS` and
 :py:`LOAD_FACADE`, which can be set to :py:`True` or :py:`False`.  Although these options control how the OpenVSP API is loaded,
 these differences should otherwise be transparent to the user.  I.e. no changes to a user's code are required when
 changing from one API mode to another.
@@ -72,7 +72,7 @@ set :py:`openvsp_config.LOAD_GRAPHICS = True` before you import :py:`openvsp` as
     vsp.StartGUI()
 
 Note that when the GUI is running in this mode, complete program flow control has been transferred to the GUI.  While
-the GUI is fully interactive, Python execution will halt until the user stops the GUI by slecting :py:`Stop GUI` from the File
+the GUI is fully interactive, Python execution will halt until the user stops the GUI by selecting :py:`Stop GUI` from the File
 menu in the OpenVSP GUI.
 
 OpenVSP API in Separate Python Process


### PR DESCRIPTION
Found via `codespell -q 3 -S ./.git,./src/external -L abd,abnd,acount,afile,ans,arry,ba,bu,childrens,cna,combind,defint,dum,finess,fo,fom,idel,inout,inpt,lod,momento,nam,numer,nwe,orgin,ot,parm,parma,ptd,parms,pres,siz,statics,te,tesselate,tesselation,tey,uptodate,wit`