### PR TITLE
README: Add a downstream packaging repology status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,3 +377,7 @@
    9. Right-click on PACKAGE in the Solution Explorer and select
    Build.  This packages all the directories and executables in a zip
    file.  This zip file will be placed in .../build/vsp/.
+
+### PACKAGING STATUS
+
+[![OpenVSP Packaging Status](https://repology.org/badge/vertical-allrepos/openvsp.svg?columns=3&header=OpenVSP)](https://repology.org/project/openvsp/versions)


### PR DESCRIPTION
This badge enables users to see what downstream package versions are available for OpenVSP. Repology badges are a huge timesaver for maintainers and users. Here's OpenVSP's standing: https://repology.org/project/openvsp/versions

### Proposal

![Screenshot_20240730_110800](https://github.com/user-attachments/assets/e98cee9f-42ef-4df7-aa20-8c7ae98c2172)

### Example

https://github.com/luzpaz/OpenVSP/blob/README-Repology-badge/README.md#packaging-status