### PR TITLE
Fix build with stricter libc++

### DIFF
--- a/src/external/GeometricTools/GeometricTools/GTE/Mathematics/BSNumber.h
+++ b/src/external/GeometricTools/GeometricTools/GTE/Mathematics/BSNumber.h
@@ -1387,9 +1387,6 @@ namespace std
         return (gte::BSNumber<UInteger>)std::tanh((double)x);
     }
 
-    // Type trait that says BSNumber is a signed type.
-    template <typename UInteger>
-    struct is_signed<gte::BSNumber<UInteger>> : true_type {};
 }
 
 namespace gte


### PR DESCRIPTION
While building in a newer system in FreeBSD, this error is shown.

See https://lists.freebsd.org/archives/freebsd-pkg-fallout/2026-May/938039.html for details.
