### PR TITLE
fix: use delete[] for array

### DIFF
--- a/src/vsp_aero/Solver/VSP_Geom.C
+++ b/src/vsp_aero/Solver/VSP_Geom.C
@@ -1365,7 +1365,7 @@ void VSP_GEOM::SanitizeThinMeshes(void)
        
     }
     
-    delete UsedTri;
+    delete [] UsedTri;
              
     // Calculate total number of nodes and tris, including the wake
         


### PR DESCRIPTION
Replaced delete with array delete[] to properly free allocated memory.