### PR TITLE
Fix no-graphics STEP export segfault (patch vendored STEPCode NULL-this deref)

### DIFF
--- a/Libraries/cmake/External_STEPCode.cmake
+++ b/Libraries/cmake/External_STEPCode.cmake
@@ -20,6 +20,19 @@ ENDIF()
 ExternalProject_Add( STEPCODE
 	URL ${CMAKE_CURRENT_SOURCE_DIR}/stepcode-28350d91294b.zip
 	DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+	# The bundled STEPCode snapshot (28350d9, ~2016) predates the upstream fix
+	# for a NULL-pointer dereference in complex-entity matching (stepcode/stepcode
+	# commit 345bcd81 "Check before dereferencing...", released in v0.8.1).
+	# Without it, optimizing compilers (notably gcc, which enables
+	# -fdelete-null-pointer-checks) drop the guard in EntList::firstNot(), so the
+	# end-of-list step in the complex-entity match walk dereferences a NULL `this`
+	# and every STEP export segfaults in STEPutil::Geometric_Context before any
+	# geometry is written.  Overlay the fixed header (which is the bundled file
+	# plus the upstream 4-line guard) until the vendored STEPCode is updated.
+	PATCH_COMMAND
+		${CMAKE_COMMAND} -E copy_if_different
+		"${CMAKE_CURRENT_SOURCE_DIR}/stepcode_complexSupport.h"
+		"<SOURCE_DIR>/src/clstepcore/complexSupport.h"
 	CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
 		-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
 		-DCMAKE_CXX_FLAGS=${SC_CMAKE_CXX_FLAGS}

--- a/Libraries/stepcode_complexSupport.h
+++ b/Libraries/stepcode_complexSupport.h
@@ -1,0 +1,423 @@
+#ifndef COMPLEXSUP_H
+#define COMPLEXSUP_H
+
+/*****************************************************************************
+ * complexSupport.h                                                          *
+ *                                                                           *
+ * Description: Slightly simplified version of exp2cxx's complexSupport.h.*
+ *              This version works with the SCL and is used to validate      *
+ *              complex entities (user requests to build them).  It does not *
+ *              contain info for building these structures from a fedex      *
+ *              Express object, as the exp2cxx version.                   *
+ *                                                                           *
+ * Created by:  David Rosenfeld                                              *
+ * Date:        5/9/97                                                       *
+ *****************************************************************************/
+
+#include <sc_export.h>
+#include <iostream>
+#include <fstream>
+using namespace std;
+#include "Str.h"
+
+#define LISTEND 999
+/** \def LISTEND
+ * signifies that an OrList has gone beyond its last viable choice
+ * among its children. FIXME is 999 high enough? Maybe use -1?
+ */
+
+enum MarkType {
+    NOMARK, ORMARK, MARK
+};
+/** \enum MarkType
+// MARK is the usual value we'd mark with.  If we mark with ORMARK, it means
+// an OrList marked this node, so we'll know it may become unmarked later if
+// we try another choice.
+*/
+
+enum MatchType {
+    UNKNOWN, UNSATISFIED, SATISFIED, MATCHSOME, MATCHALL, NEWCHOICE, NOMORE
+};
+/** \enum MatchType
+// These are the conditions the EntList::match() functions may return.  They
+// are also the assigned values to EntList::viable.
+//
+//    UNKNOWN     - The default EntList::viable value - before any matching
+//                  has been attempted.
+//    UNSATISFIED - EntList had conditions that EntNode did not satisfy (e.g.,
+//                  EntList specified A AND B while EntNode only contained an
+//                  A).
+//    SATISFIED   - EntList had no conditions EntNode did not meet.  But,
+//                  EntList did not match (mark) any nodes of EntNode which
+//                  were not already matched.
+//    MATCHSOME   - EntList matched some of the nodes in EntNode.
+//    MATCHALL    - EntList matched all the nodes in EntNode (complex entity
+//                  can be instantiated).
+//    MORECHOICES - Special case - when trying alternate OR paths, this return
+//                  value signifies that we have found another choice.
+//    NOMORE      - Special case - when trying alternate OR paths, this return
+//                  value signifies that no more alternates within this path.
+*/
+
+enum JoinType {
+    SIMPLE, AND, OR, ANDOR
+};
+
+class SimpleList;
+class MultList;
+class JoinList;
+class AndOrList;
+class AndList;
+class OrList;
+class ComplexList;
+class ComplexCollect;
+
+class SC_CORE_EXPORT EntNode {
+        friend class SimpleList;
+        friend class AndOrList;
+        friend class AndList;
+        friend class OrList;
+        friend class ComplexList;
+
+    public:
+        EntNode( const char * nm = "" ) : next( 0 ), mark( NOMARK ), multSupers( 0 ) {
+            StrToLower( nm, name );
+        }
+        EntNode( const char ** );                ///< given a list, create a linked list of EntNodes
+        ~EntNode() {
+            if( next ) {
+                delete next;
+            }
+        }
+        operator const char * () {
+            return name;
+        }
+        bool operator== ( EntNode & ent ) {
+            return ( strcmp( name, ent.name ) == 0 );
+        }
+        bool operator< ( EntNode & ent ) {
+            return ( strcmp( name, ent.name ) < 0 );
+        }
+        bool operator> ( EntNode & ent ) {
+            return ( strcmp( name, ent.name ) > 0 );
+        }
+        EntNode & operator= ( EntNode & ent );
+        void Name( const char * nm ) {
+            strncpy( name, nm, BUFSIZ - 1 );
+        }
+        const char * Name() {
+            return name;
+        }
+        void setmark( MarkType stamp = MARK ) {
+            mark = stamp;
+        }
+        void markAll( MarkType = MARK );
+        void unmarkAll() {
+            markAll( NOMARK );
+        }
+        bool  marked( MarkType base = ORMARK ) {
+            return ( mark >= base );
+        }
+        bool  allMarked();  ///< returns true if all nodes in list are marked
+        int  unmarkedCount();
+        bool  multSuprs() {
+            return multSupers;
+        }
+        void multSuprs( int j ) {
+            multSupers = j;
+        }
+        void sort( EntNode ** );
+
+        EntNode * next;
+
+    private:
+        MarkType mark;
+        char name[BUFSIZ];
+        bool multSupers;  ///< do I correspond to an entity with >1 supertype?
+        EntNode * lastSmaller( EntNode * ); ///< used by ::sort()
+};
+
+class SC_CORE_EXPORT EntList {
+        friend class MultList;
+        friend class JoinList;
+        friend class OrList;
+        friend class ComplexList;
+        friend class ComplexCollect;
+        friend ostream & operator<< ( ostream &, EntList & );
+        friend ostream & operator<< ( ostream &, MultList & );
+
+    public:
+        EntList( JoinType j ) : join( j ), next( 0 ), prev( 0 ), viable( UNKNOWN ),
+            level( 0 ) {}
+        virtual ~EntList() {}
+        MatchType viableVal() {
+            return viable;
+        }
+        virtual void setLevel( int l ) {
+            level = l;
+        }
+        virtual bool contains( char * ) = 0;
+        virtual bool hit( char * ) = 0;
+        virtual MatchType matchNonORs( EntNode * ) {
+            return UNKNOWN;
+        }
+        virtual bool acceptChoice( EntNode * ) = 0;
+        virtual void unmarkAll( EntNode * ) = 0;
+        virtual void reset() {
+            viable = UNKNOWN;
+        }
+        int siblings();
+
+        // List access functions.  They access desired children based on their
+        // join or viable values.  Below is an incomplete list of possible fns,
+        // but all we need.
+        EntList * firstNot( JoinType );
+        EntList * nextNot( JoinType j ) {
+            return ( next ) ? next->firstNot( j ) : NULL;
+        }
+        EntList * firstWanted( MatchType );
+        EntList * nextWanted( MatchType mat ) {
+            return ( next ) ? next->firstWanted( mat ) : NULL;
+        }
+        EntList * lastNot( JoinType );
+        EntList * prevNot( JoinType j ) {
+            return ( prev ) ? prev->lastNot( j ) : NULL;
+        }
+        EntList * lastWanted( MatchType );
+        EntList * prevWanted( MatchType mat ) {
+            return ( prev ) ? prev->lastWanted( mat ) : NULL;
+        }
+
+        JoinType join;
+        int multiple() {
+            return ( join != SIMPLE );
+        }
+        EntList * next, *prev;
+
+    protected:
+        MatchType viable;
+        /** \var viable
+         * How does this EntList match the complex type.  Used especially if Ent-
+         * List's parent is an OrList or AndOrList to record if this child is an
+         * acceptable choice or not.  For an AndOr, viable children are accepted
+         * right away.  For Or, only one is accepted, but we keep track of the
+         * other possible solutions in case we'll want to try them.
+         */
+        int level;  ///< How many levels deep are we (main use for printing).
+};
+
+class SC_CORE_EXPORT SimpleList : public EntList {
+        friend class ComplexList;
+        friend ostream & operator<< ( ostream &, SimpleList & );
+
+    public:
+        SimpleList( const char * n ) : EntList( SIMPLE ), I_marked( NOMARK ) {
+            strncpy( name, n, sizeof( name ) - 1 );
+            name[sizeof( name ) - 1] = '\0'; /* sanity */
+        }
+        ~SimpleList() {}
+        int operator== ( const char * nm ) {
+            return ( strcmp( name, nm ) == 0 );
+        }
+        const char * Name() {
+            return name;
+        }
+        bool contains( char * nm ) {
+            return *this == nm;
+        }
+        bool hit( char * nm ) {
+            return *this == nm;
+        }
+        MatchType matchNonORs( EntNode * );
+        bool acceptChoice( EntNode * );
+        void unmarkAll( EntNode * );
+        void reset() {
+            viable = UNKNOWN;
+            I_marked = NOMARK;
+        }
+
+    private:
+        char name[BUFSIZ];    ///< Name of entity we correspond to.
+        MarkType I_marked; ///< Did I mark, and with what type of mark.
+};
+
+/** \class MultList
+ * Supports concepts and functionality common to all the compound list
+ * types, especially AND and ANDOR.
+ */
+class SC_CORE_EXPORT MultList : public EntList {
+
+        friend class ComplexList;
+        friend class ComplexCollect;
+        friend ostream & operator<< ( ostream &, MultList & );
+
+    public:
+        MultList( JoinType j ) : EntList( j ), supertype( 0 ), numchildren( 0 ),
+            childList( 0 ) {}
+        ~MultList();
+        void setLevel( int );
+        bool contains( char * );
+        bool hit( char * );
+        void appendList( EntList * );
+        EntList * copyList( EntList * );
+        virtual MatchType matchORs( EntNode * ) = 0;
+        virtual MatchType tryNext( EntNode * );
+
+        int childCount() {
+            return numchildren;
+        }
+//  EntList *operator[]( int );
+        EntList * getChild( int );
+        EntList * getLast() {
+            return ( getChild( numchildren - 1 ) );
+        }
+        void unmarkAll( EntNode * );
+        bool prevKnown( EntList * );
+        void reset();
+
+    protected:
+        int supertype;  ///< do I represent a supertype?
+        int numchildren;
+        EntList * childList;
+        /** \var childList
+         * Points to a list of "children" of this EntList.  E.g., if join =
+         * AND, it would point to a list of the entity types we are AND'ing.
+         * The children may be SIMPLE EntLists (contain entity names) or may
+         * themselves be And-, Or-, or AndOrLists.
+         */
+};
+
+/** \class JoinList
+ * A specialized MultList, super for subtypes AndOrList and AndList, or
+ * ones which join their multiple children.
+ */
+class SC_CORE_EXPORT JoinList : public MultList {
+    public:
+        JoinList( JoinType j ) : MultList( j ) {}
+        ~JoinList() {}
+        void setViableVal( EntNode * );
+        bool acceptChoice( EntNode * );
+};
+
+class SC_CORE_EXPORT AndOrList : public JoinList {
+        friend class ComplexList;
+
+    public:
+        AndOrList() : JoinList( ANDOR ) {}
+        ~AndOrList() {}
+        MatchType matchNonORs( EntNode * );
+        MatchType matchORs( EntNode * );
+};
+
+class SC_CORE_EXPORT AndList : public JoinList {
+        friend class ComplexList;
+        friend ostream & operator<< ( ostream &, ComplexList & );
+
+    public:
+        AndList() : JoinList( AND ) {}
+        ~AndList() {}
+        MatchType matchNonORs( EntNode * );
+        MatchType matchORs( EntNode * );
+};
+
+class SC_CORE_EXPORT OrList : public MultList {
+    public:
+        OrList() : MultList( OR ), choice( -1 ), choice1( -1 ), choiceCount( 0 ) {}
+        ~OrList() {}
+        bool hit( char * );
+        MatchType matchORs( EntNode * );
+        MatchType tryNext( EntNode * );
+        void unmarkAll( EntNode * );
+        bool acceptChoice( EntNode * );
+        bool acceptNextChoice( EntNode * ents ) {
+            choice++;
+            return ( acceptChoice( ents ) );
+        }
+        void reset() {
+            choice = -1;
+            choice1 = -2;
+            choiceCount = 0;
+            MultList::reset();
+        }
+
+    private:
+        int choice;      ///< Which choice of our childList did we select from this OrList
+        int choice1;     ///< what's the first viable choice
+        int choiceCount; ///< how many choices are there entirely.
+};
+
+/** \class ComplexList
+ * Contains the entire list of EntLists which describe the set of
+ * instantiable complex entities defined by an EXPRESS expression.
+ */
+class SC_CORE_EXPORT ComplexList {
+        friend class ultList;
+        friend class ComplexCollect;
+        friend ostream & operator<< ( ostream &, ComplexList & );
+
+    public:
+        ComplexList( AndList * alist = NULL ) : list( 0 ), head( alist ), next( 0 ),
+            abstract( 0 ), dependent( 0 ),
+            multSupers( 0 ) {}
+        ~ComplexList();
+        void buildList();
+        void remove();
+        int operator< ( ComplexList & c ) {
+            return ( strcmp( supertype(), c.supertype() ) < 0 );
+        }
+        int operator< ( char * name ) {
+            return ( strcmp( supertype(), name ) < 0 );
+        }
+        int operator== ( char * name ) {
+            return ( strcmp( supertype(), name ) == 0 );
+        }
+        const char * supertype() {
+            return ( dynamic_cast< SimpleList * >(head->childList ))->name ;
+        }
+        /** \fn supertype
+         * Based on knowledge that ComplexList always created by ANDing supertype
+         * with subtypes.
+         */
+        bool toplevel( const char * );
+        bool contains( EntNode * );
+        bool matches( EntNode * );
+
+        EntNode * list; /**< List of all entities contained in this complex type,
+                    *   regardless of how.  (Used as a quick way of determining
+                    *   if this List *may* contain a certain complex type.)
+                    */
+        AndList * head;
+        ComplexList * next;
+        int Dependent() {
+            return dependent;
+        }
+
+    private:
+        void addChildren( EntList * );
+        bool hitMultNodes( EntNode * );
+        int abstract;   ///< is our supertype abstract?
+        int dependent;  ///< is our supertype also a subtype of other supertype(s)?
+        bool multSupers; ///< am I a combo-CList created to test a subtype which has >1 supertypes?
+};
+
+/// The collection of all the ComplexLists defined by the current schema.
+class SC_CORE_EXPORT ComplexCollect {
+    public:
+        ComplexCollect( ComplexList * c = NULL ) : clists( c ) {
+            count = ( c ? 1 : 0 );
+        }
+        ~ComplexCollect() {
+            delete clists;
+        }
+        void insert( ComplexList * );
+        void remove( ComplexList * ); ///< Remove this list but don't delete its hierarchy structure, because it's used elsewhere.
+        ComplexList * find( char * );
+        bool supports( EntNode * ) const;
+
+        ComplexList * clists;
+
+    private:
+        int count;  ///< # of clist children
+};
+
+#endif


### PR DESCRIPTION
## What this fixes

In no-graphics builds, **every** STEP export (`EXPORT_STEP` and the SurfaceIntersection STEP export) segfaults in the `STEPutil` constructor while building the units/representation-context boilerplate — before any geometry is written. IGES export is unaffected. It reproduces in the conda `no_graphics` package and in from-source gcc builds; GUI/clang builds happen to work.

```
#0  EntList::firstNot (this=0x0, j=OR)   clstepcore/entlist.cc:39   ← NULL deref
#1  EntList::nextNot                      clstepcore/complexSupport.h
#2  AndList::matchNonORs                  clstepcore/non-ors.cc:135
#3  ComplexList::matches                  clstepcore/complexlist.cc:176
#4  ComplexCollect::supports              clstepcore/collect.cc:140
#5  STEPcomplex::Initialize               clstepcore/STEPcomplex.cc:127
#6  STEPcomplex::STEPcomplex
#7  STEPutil::Geometric_Context
```

## Root cause

Constructing any complex entity validates the type combination by walking the schema's registered complex-entity rules. The walk advances with `child = child->nextNot(OR)`, and `EntList::nextNot` is `return next->firstNot(j);`. At the end of a sibling list `next == NULL`, so this calls `firstNot()` with `this == NULL`.

`firstNot()` *looks* safe — it starts `EntList *sibling = this;` then `while (sibling != NULL && ...)`. But calling a non-static member function through a NULL pointer is undefined behavior, and optimizing compilers exploit it: **gcc's `-fdelete-null-pointer-checks` (on by default at `-O1`+) assumes `this` is non-NULL and deletes the `sibling != NULL` guard**, so the end-of-list case dereferences NULL at `entlist.cc:39`. clang keeps the guard (verified by disassembly: `firstNot` opens with `cbz x0`), which is exactly why GUI/clang builds dodge it and gcc no-graphics builds don't. It fires for every complex entity, so every STEP export dies identically.

## Why it's still here

**STEPCode already fixed this upstream** — commit [`345bcd81`](https://github.com/stepcode/stepcode/commit/345bcd8174bb106506f88f668f3537d9a0c15c92) (*"Check before dereferencing, and initialize to NULL"*), released in **v0.8.1**, guards the four `EntList` wrappers. OpenVSP bundles a ~2016 snapshot (`stepcode-28350d91294b.zip`) that predates that fix.

## The change

Rather than re-vendoring the whole zip (an unreviewable binary change) or bumping STEPCode wholesale (a much larger, riskier change given the pinned snapshot), this overlays a corrected `complexSupport.h` onto the extracted source via `PATCH_COMMAND` — matching the existing `External_CppTest.cmake` pattern. `Libraries/stepcode_complexSupport.h` is the bundled file plus the **exact** upstream 4-line guard:

```cpp
EntList * nextNot( JoinType j )     { return ( next ) ? next->firstNot( j )    : NULL; }
EntList * nextWanted( MatchType m ) { return ( next ) ? next->firstWanted( m ) : NULL; }
EntList * prevNot( JoinType j )     { return ( prev ) ? prev->lastNot( j )     : NULL; }
EntList * prevWanted( MatchType m ) { return ( prev ) ? prev->lastWanted( m )  : NULL; }
```

(Longer term, bumping the vendored STEPCode to ≥ v0.8.1 would make this overlay unnecessary.)

## Verification (both platforms)

**Linux (Ubuntu 22.04, x86-64, conda-forge gcc 14.3.0 at `-O2` — the configuration the `no_graphics` conda packages use):** an existing `VSP_NO_GRAPHICS` build reproduces the crash — `vspscript` running `AddGeom("WING"); ExportFile(..., EXPORT_STEP)` segfaults (exit 139) before writing anything. After applying this fix and rebuilding `libstepcore` + relinking, the same run exits 0 and writes a valid STEP file (12 `B_SPLINE_SURFACE`, the `GEOMETRIC_REPRESENTATION_CONTEXT` complex, `END-ISO-10303-21`). Note: even a nominally `Debug` build hits this, because conda injects `-O2` into the base `CMAKE_CXX_FLAGS`.

**macOS (Apple Silicon, arm64):** a standalone **gcc `-O2`** build of the bundled STEPCode reproduces the exact crash (`firstNot this=0x0`, `entlist.cc:39`, `EXC_BAD_ACCESS @ 0x8` = `this->join`) and stops crashing with the patch. **clang `-O2` never crashed** (it keeps the guard — verified by disassembly), so GUI/clang builds are unaffected either way. A full `VSP_NO_GRAPHICS` build with this PR exports a valid STEP for a WING (`EXPORT_STEP`) and a watertight trimmed `MANIFOLD_SOLID_BREP` for a fuselage+wing via the SurfaceIntersection analysis (`STEP_BREP`) — one `CLOSED_SHELL` of 16 mutually-trimmed `ADVANCED_FACE`s, 8 from each component.

## Scope / honesty

This fixes the crash that blocked the entire native STEP path; it does not touch the intersection/trimming quality itself (`SurfaceIntersectionMgr` / `NURBS.cpp`), and it does not change clang/GUI behavior (which were already fine). Header-only effect — only `libstepcore` rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
