### PR TITLE
DeltaFlatPlateDragArea fix for unsteady cases

### DIFF
--- a/src/vsp_aero/Solver/ComponentGroup.C
+++ b/src/vsp_aero/Solver/ComponentGroup.C
@@ -32,7 +32,8 @@ COMPONENT_GROUP::COMPONENT_GROUP(void)
     OVec_[0] = OVec_[1] = OVec_[2] = 0.;
     RVec_[0] = RVec_[1] = RVec_[2] = 0.;
     TVec_[0] = TVec_[1] = TVec_[2] = 0.;
-        
+    Position_[0] = Position_[1] = Position_[2] = 0.;
+
     UserInputVelocity_[0] = UserInputVelocity_[1] = UserInputVelocity_[2] = 0.;
 
     UserInputAcceleration_[0] = UserInputAcceleration_[1] = UserInputAcceleration_[2] = 0.;
@@ -211,6 +212,7 @@ COMPONENT_GROUP::~COMPONENT_GROUP(void)
     OVec_[0] = OVec_[1] = OVec_[2] = 0.;
     RVec_[0] = RVec_[1] = RVec_[2] = 0.;
     TVec_[0] = TVec_[1] = TVec_[2] = 0.;
+    Position_[0] = Position_[1] = Position_[2] = 0.;
 
     Velocity_(1) = Velocity_(2) = Velocity_(3) = 0.;
     
@@ -402,6 +404,10 @@ COMPONENT_GROUP &COMPONENT_GROUP::operator=(const COMPONENT_GROUP &ComponentGrou
     TVec_[0] = ComponentGroup.TVec_[0];
     TVec_[1] = ComponentGroup.TVec_[1];
     TVec_[2] = ComponentGroup.TVec_[2];
+
+    Position_[0] = ComponentGroup.Position_[0];
+    Position_[1] = ComponentGroup.Position_[1];
+    Position_[2] = ComponentGroup.Position_[2];
  
     UserInputVelocity_[0] = ComponentGroup.UserInputVelocity_[0];
     UserInputVelocity_[1] = ComponentGroup.UserInputVelocity_[1];
@@ -696,6 +702,10 @@ void COMPONENT_GROUP::ZeroOutTotals(void)
     TotalQuat_(1) = 0.;
     TotalQuat_(2) = 0.;
     TotalQuat_(3) = 1.;
+
+    Position_[0] = 0.;
+    Position_[1] = 0.;
+    Position_[2] = 0.;
        
 }
 
@@ -915,6 +925,10 @@ void COMPONENT_GROUP::UpdateDynamicSystem(void)
     TVec_[0] = Velocity_(1) * DeltaTime_;
     TVec_[1] = Velocity_(2) * DeltaTime_;
     TVec_[2] = Velocity_(3) * DeltaTime_;
+
+    Position_[0] += TVec_[0];
+    Position_[1] += TVec_[1];
+    Position_[2] += TVec_[2];
 
     // Moments
 
@@ -1266,7 +1280,11 @@ void COMPONENT_GROUP::LoadData(FILE *File)
     TotalQuat_(1) = 0.;
     TotalQuat_(2) = 0.;
     TotalQuat_(3) = 1.;
-    
+
+    Position_[0] = 0.;
+    Position_[1] = 0.;
+    Position_[2] = 0.;
+
     // Calculate blade rpm
     
     RPM_ = 60. * Omega_ / (2. * PI);

--- a/src/vsp_aero/Solver/ComponentGroup.H
+++ b/src/vsp_aero/Solver/ComponentGroup.H
@@ -47,6 +47,7 @@ private:
     double OVec_[3];
     double RVec_[3];
     double TVec_[3];
+    double Position_[3];
     
     double UserInputVelocity_[3];
     double UserInputAcceleration_[3];
@@ -580,6 +581,10 @@ public:
     /** Translation vector to be applied in transformations **/
 
     double TVec(int i) { return TVec_[i]; };
+    
+    /** Accumulated translation position of the group **/
+
+    double &Position(int i) { return Position_[i]; };
 
     /** Velocity of group **/
         

--- a/src/vsp_aero/Solver/VSP_Solver.C
+++ b/src/vsp_aero/Solver/VSP_Solver.C
@@ -3002,7 +3002,18 @@ void VSP_SOLVER::Solve(int Case)
 
                             //1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456 1234567890123456
        fprintf(GroupFile_[c],"Force Coefficients for group %d --> %s \n\n",c,VSPGeom().ComponentGroupList(c).GroupName()); 
-       fprintf(GroupFile_[c],"      Time              Cx               Cy               Cz               Cxo              Cyo              Czo              Cxi              Cyi              Czi              Cmx              Cmy              Cmz             Cmxo            Cmyo              Cmzo             Cmxi             Cmyi             Cmzi              CL               CD               CS              CLo              CDo              CSo              CLi               CDi             CSi              Cwx              Cwy              Cwz              Cxiw             Cyiw             Cziw             CLw              CDw              CSw               CLiw            CDiw             CSiw\n");
+       
+       if ( VSPGeom().ComponentGroupList(c).GeometryIsDynamic() == FULL_DYNAMIC ) {
+
+          fprintf(GroupFile_[c],"      Time               X                Y                Z             Pitch            Roll             Yaw               Cx               Cy               Cz               Cxo              Cyo              Czo              Cxi              Cyi              Czi              Cmx              Cmy              Cmz             Cmxo            Cmyo              Cmzo             Cmxi             Cmyi             Cmzi              CL               CD               CS              CLo              CDo              CSo              CLi               CDi             CSi              Cwx              Cwy              Cwz              Cxiw             Cyiw             Cziw             CLw              CDw              CSw               CLiw            CDiw             CSiw\n");
+
+       }
+
+       else {
+
+          fprintf(GroupFile_[c],"      Time              Cx               Cy               Cz               Cxo              Cyo              Czo              Cxi              Cyi              Czi              Cmx              Cmy              Cmz             Cmxo            Cmyo              Cmzo             Cmxi             Cmyi             Cmzi              CL               CD               CS              CLo              CDo              CSo              CLi               CDi             CSi              Cwx              Cwy              Cwz              Cxiw             Cyiw             Cziw             CLw              CDw              CSw               CLiw            CDiw             CSiw\n");
+
+       }
                           
        // Create rotor file
        
@@ -35756,6 +35767,8 @@ void VSP_SOLVER::OutputForcesAndMomentsForGroup(int Group)
     double CT, CQ, CP, EtaP, CT_h, CQ_h, CP_h, FOM;
     double J, Diameter, RPM, Time;
     double Omega, Radius, TipVelocity, Area, Vec[3];
+    double PosX, PosY, PosZ, Pitch, Roll, Yaw;
+    double Qx, Qy, Qz, Qw, SinPitch;
 
     // Loop over component groups, calculate rotor coefficients if any are
     // flagged as being rotors by the user.
@@ -35773,10 +35786,92 @@ void VSP_SOLVER::OutputForcesAndMomentsForGroup(int Group)
        if ( !TimeAccurate_ ) Time = CurrentWakeIteration_;
        
        if ( Group == 0 || c == Group ) {
-          
+
+          PosX = PosY = PosZ = 0.;
+          Pitch = Roll = Yaw = 0.;
+
+          if ( VSPGeom().ComponentGroupList(c).GeometryIsDynamic() == FULL_DYNAMIC ) {
+
+             PosX = VSPGeom().ComponentGroupList(c).Position(0);
+             PosY = VSPGeom().ComponentGroupList(c).Position(1);
+             PosZ = VSPGeom().ComponentGroupList(c).Position(2);
+
+             Qx = VSPGeom().ComponentGroupList(c).TotalQuat()(0);
+             Qy = VSPGeom().ComponentGroupList(c).TotalQuat()(1);
+             Qz = VSPGeom().ComponentGroupList(c).TotalQuat()(2);
+             Qw = VSPGeom().ComponentGroupList(c).TotalQuat()(3);
+
+             Roll = atan2(2.*(Qw*Qx + Qy*Qz), 1. - 2.*(Qx*Qx + Qy*Qy));
+
+             SinPitch = 2.*(Qw*Qy - Qz*Qx);
+             SinPitch = MAX(-1.,MIN(1.,SinPitch));
+             Pitch = asin(SinPitch);
+
+             Yaw = atan2(2.*(Qw*Qz + Qx*Qy), 1. - 2.*(Qy*Qy + Qz*Qz));
+
+             Pitch /= TORAD;
+             Roll  /= TORAD;
+             Yaw   /= TORAD;
+
+          }
           // Write out forces and moments
 
-          fprintf(GroupFile_[c],"%16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf \n",
+          if ( VSPGeom().ComponentGroupList(c).GeometryIsDynamic() == FULL_DYNAMIC ) {
+
+             fprintf(GroupFile_[c],"%16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf \n",
+
+                  Time,
+                  PosX,
+                  PosY,
+                  PosZ,
+                  Pitch,
+                  Roll,
+                  Yaw,
+                  VSPGeom().ComponentGroupList(c).CFix() + VSPGeom().ComponentGroupList(c).CFox(),
+                  VSPGeom().ComponentGroupList(c).CFiy() + VSPGeom().ComponentGroupList(c).CFoy(),
+                  VSPGeom().ComponentGroupList(c).CFiz() + VSPGeom().ComponentGroupList(c).CFoz(),
+                  VSPGeom().ComponentGroupList(c).CFox(),
+                  VSPGeom().ComponentGroupList(c).CFoy(),
+                  VSPGeom().ComponentGroupList(c).CFoz(),
+                  VSPGeom().ComponentGroupList(c).CFix(),
+                  VSPGeom().ComponentGroupList(c).CFiy(),
+                  VSPGeom().ComponentGroupList(c).CFiz(),                                    
+                  VSPGeom().ComponentGroupList(c).CMix() + VSPGeom().ComponentGroupList(c).CMox(),
+                  VSPGeom().ComponentGroupList(c).CMiy() + VSPGeom().ComponentGroupList(c).CMoy(),
+                  VSPGeom().ComponentGroupList(c).CMiz() + VSPGeom().ComponentGroupList(c).CMoz(),
+                  VSPGeom().ComponentGroupList(c).CMox(),
+                  VSPGeom().ComponentGroupList(c).CMoy(),
+                  VSPGeom().ComponentGroupList(c).CMoz(),
+                  VSPGeom().ComponentGroupList(c).CMix(),
+                  VSPGeom().ComponentGroupList(c).CMiy(),
+                  VSPGeom().ComponentGroupList(c).CMiz(),                                    
+                  VSPGeom().ComponentGroupList(c).CLi() + VSPGeom().ComponentGroupList(c).CLo(),
+                  VSPGeom().ComponentGroupList(c).CDi() + VSPGeom().ComponentGroupList(c).CDo(),
+                  VSPGeom().ComponentGroupList(c).CSi() + VSPGeom().ComponentGroupList(c).CSo(),
+                  VSPGeom().ComponentGroupList(c).CLo(),
+                  VSPGeom().ComponentGroupList(c).CDo(),   
+                  VSPGeom().ComponentGroupList(c).CSo(),                     
+                  VSPGeom().ComponentGroupList(c).CLi(),                  
+                  VSPGeom().ComponentGroupList(c).CDi(),
+                  VSPGeom().ComponentGroupList(c).CSi(),
+                  VSPGeom().ComponentGroupList(c).CFiwx() + VSPGeom().ComponentGroupList(c).CFox(),
+                  VSPGeom().ComponentGroupList(c).CFiwy() + VSPGeom().ComponentGroupList(c).CFoy(),
+                  VSPGeom().ComponentGroupList(c).CFiwz() + VSPGeom().ComponentGroupList(c).CFoz(),
+                  VSPGeom().ComponentGroupList(c).CFiwx(),
+                  VSPGeom().ComponentGroupList(c).CFiwy(),
+                  VSPGeom().ComponentGroupList(c).CFiwz(),                        
+                  VSPGeom().ComponentGroupList(c).CLiw() + VSPGeom().ComponentGroupList(c).CLo(),
+                  VSPGeom().ComponentGroupList(c).CDiw() + VSPGeom().ComponentGroupList(c).CDo(),
+                  VSPGeom().ComponentGroupList(c).CSiw() + VSPGeom().ComponentGroupList(c).CSo(),
+                  VSPGeom().ComponentGroupList(c).CLiw(),                  
+                  VSPGeom().ComponentGroupList(c).CDiw(),
+                  VSPGeom().ComponentGroupList(c).CSiw());    
+
+          }
+
+          else {
+
+             fprintf(GroupFile_[c],"%16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf \n",
 
                   Time,
                   VSPGeom().ComponentGroupList(c).CFix() + VSPGeom().ComponentGroupList(c).CFox(),
@@ -35817,7 +35912,9 @@ void VSP_SOLVER::OutputForcesAndMomentsForGroup(int Group)
                   VSPGeom().ComponentGroupList(c).CSiw() + VSPGeom().ComponentGroupList(c).CSo(),
                   VSPGeom().ComponentGroupList(c).CLiw(),                  
                   VSPGeom().ComponentGroupList(c).CDiw(),
-                  VSPGeom().ComponentGroupList(c).CSiw());    
+                  VSPGeom().ComponentGroupList(c).CSiw());
+
+                 }
                               
           // Write out time averaged forces for time accurate solutions
 
@@ -35829,48 +35926,104 @@ void VSP_SOLVER::OutputForcesAndMomentsForGroup(int Group)
              fprintf(GroupFile_[c],"Time averaged forces and moments: \n");
              fprintf(GroupFile_[c],"\n");
 
-             fprintf(GroupFile_[c],"%16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf \n",
+             if ( VSPGeom().ComponentGroupList(c).GeometryIsDynamic() == FULL_DYNAMIC ) {
+                fprintf(GroupFile_[c],"%16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf \n",
 
-                     Time,
-                     VSPGeom().ComponentGroupList(c).CFix_avg() + VSPGeom().ComponentGroupList(c).CFox_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiy_avg() + VSPGeom().ComponentGroupList(c).CFoy_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiz_avg() + VSPGeom().ComponentGroupList(c).CFoz_avg(),
-                     VSPGeom().ComponentGroupList(c).CFox_avg(),
-                     VSPGeom().ComponentGroupList(c).CFoy_avg(),
-                     VSPGeom().ComponentGroupList(c).CFoz_avg(),
-                     VSPGeom().ComponentGroupList(c).CFix_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiy_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiz_avg(),                                    
-                     VSPGeom().ComponentGroupList(c).CMix_avg() + VSPGeom().ComponentGroupList(c).CMox_avg(),
-                     VSPGeom().ComponentGroupList(c).CMiy_avg() + VSPGeom().ComponentGroupList(c).CMoy_avg(),
-                     VSPGeom().ComponentGroupList(c).CMiz_avg() + VSPGeom().ComponentGroupList(c).CMoz_avg(),
-                     VSPGeom().ComponentGroupList(c).CMox_avg(),
-                     VSPGeom().ComponentGroupList(c).CMoy_avg(),
-                     VSPGeom().ComponentGroupList(c).CMoz_avg(),
-                     VSPGeom().ComponentGroupList(c).CMix_avg(),
-                     VSPGeom().ComponentGroupList(c).CMiy_avg(),
-                     VSPGeom().ComponentGroupList(c).CMiz_avg(),                                    
-                     VSPGeom().ComponentGroupList(c).CLo_avg() + VSPGeom().ComponentGroupList(c).CLi_avg(),
-                     VSPGeom().ComponentGroupList(c).CDo_avg() + VSPGeom().ComponentGroupList(c).CDi_avg(),
-                     VSPGeom().ComponentGroupList(c).CSo_avg() + VSPGeom().ComponentGroupList(c).CSi_avg(),                        
-                     VSPGeom().ComponentGroupList(c).CLo_avg(),
-                     VSPGeom().ComponentGroupList(c).CDo_avg(),   
-                     VSPGeom().ComponentGroupList(c).CSo_avg(),                           
-                     VSPGeom().ComponentGroupList(c).CLi_avg(),                  
-                     VSPGeom().ComponentGroupList(c).CDi_avg(),
-                     VSPGeom().ComponentGroupList(c).CSi_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiwx_avg() + VSPGeom().ComponentGroupList(c).CFox_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiwy_avg() + VSPGeom().ComponentGroupList(c).CFoy_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiwz_avg() + VSPGeom().ComponentGroupList(c).CFoz_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiwx_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiwy_avg(),
-                     VSPGeom().ComponentGroupList(c).CFiwz_avg(),                        
-                     VSPGeom().ComponentGroupList(c).CLiw_avg() + VSPGeom().ComponentGroupList(c).CLo_avg(),
-                     VSPGeom().ComponentGroupList(c).CDiw_avg() + VSPGeom().ComponentGroupList(c).CDo_avg(),
-                     VSPGeom().ComponentGroupList(c).CSiw_avg() + VSPGeom().ComponentGroupList(c).CSo_avg(),
-                     VSPGeom().ComponentGroupList(c).CLiw_avg(),                  
-                     VSPGeom().ComponentGroupList(c).CDiw_avg(),
-                     VSPGeom().ComponentGroupList(c).CSiw_avg());                            
+                  Time,
+                  PosX,
+                  PosY,
+                  PosZ,
+                  Pitch,
+                  Roll,
+                  Yaw,
+                  VSPGeom().ComponentGroupList(c).CFix_avg() + VSPGeom().ComponentGroupList(c).CFox_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiy_avg() + VSPGeom().ComponentGroupList(c).CFoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiz_avg() + VSPGeom().ComponentGroupList(c).CFoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CFox_avg(),
+                  VSPGeom().ComponentGroupList(c).CFoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CFix_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiz_avg(),                                    
+                  VSPGeom().ComponentGroupList(c).CMix_avg() + VSPGeom().ComponentGroupList(c).CMox_avg(),
+                  VSPGeom().ComponentGroupList(c).CMiy_avg() + VSPGeom().ComponentGroupList(c).CMoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CMiz_avg() + VSPGeom().ComponentGroupList(c).CMoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CMox_avg(),
+                  VSPGeom().ComponentGroupList(c).CMoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CMoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CMix_avg(),
+                  VSPGeom().ComponentGroupList(c).CMiy_avg(),
+                  VSPGeom().ComponentGroupList(c).CMiz_avg(),                                    
+                  VSPGeom().ComponentGroupList(c).CLo_avg() + VSPGeom().ComponentGroupList(c).CLi_avg(),
+                  VSPGeom().ComponentGroupList(c).CDo_avg() + VSPGeom().ComponentGroupList(c).CDi_avg(),
+                  VSPGeom().ComponentGroupList(c).CSo_avg() + VSPGeom().ComponentGroupList(c).CSi_avg(),                        
+                  VSPGeom().ComponentGroupList(c).CLo_avg(),
+                  VSPGeom().ComponentGroupList(c).CDo_avg(),   
+                  VSPGeom().ComponentGroupList(c).CSo_avg(),                           
+                  VSPGeom().ComponentGroupList(c).CLi_avg(),                  
+                  VSPGeom().ComponentGroupList(c).CDi_avg(),
+                  VSPGeom().ComponentGroupList(c).CSi_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwx_avg() + VSPGeom().ComponentGroupList(c).CFox_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwy_avg() + VSPGeom().ComponentGroupList(c).CFoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwz_avg() + VSPGeom().ComponentGroupList(c).CFoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwx_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwz_avg(),                        
+                  VSPGeom().ComponentGroupList(c).CLiw_avg() + VSPGeom().ComponentGroupList(c).CLo_avg(),
+                  VSPGeom().ComponentGroupList(c).CDiw_avg() + VSPGeom().ComponentGroupList(c).CDo_avg(),
+                  VSPGeom().ComponentGroupList(c).CSiw_avg() + VSPGeom().ComponentGroupList(c).CSo_avg(),
+                  VSPGeom().ComponentGroupList(c).CLiw_avg(),                  
+                  VSPGeom().ComponentGroupList(c).CDiw_avg(),
+                  VSPGeom().ComponentGroupList(c).CSiw_avg());
+
+             }
+
+             else {
+
+               fprintf(GroupFile_[c],"%16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf %16.12lf \n",
+
+                  Time,
+                  VSPGeom().ComponentGroupList(c).CFix_avg() + VSPGeom().ComponentGroupList(c).CFox_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiy_avg() + VSPGeom().ComponentGroupList(c).CFoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiz_avg() + VSPGeom().ComponentGroupList(c).CFoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CFox_avg(),
+                  VSPGeom().ComponentGroupList(c).CFoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CFix_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiz_avg(),                                    
+                  VSPGeom().ComponentGroupList(c).CMix_avg() + VSPGeom().ComponentGroupList(c).CMox_avg(),
+                  VSPGeom().ComponentGroupList(c).CMiy_avg() + VSPGeom().ComponentGroupList(c).CMoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CMiz_avg() + VSPGeom().ComponentGroupList(c).CMoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CMox_avg(),
+                  VSPGeom().ComponentGroupList(c).CMoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CMoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CMix_avg(),
+                  VSPGeom().ComponentGroupList(c).CMiy_avg(),
+                  VSPGeom().ComponentGroupList(c).CMiz_avg(),                                    
+                  VSPGeom().ComponentGroupList(c).CLo_avg() + VSPGeom().ComponentGroupList(c).CLi_avg(),
+                  VSPGeom().ComponentGroupList(c).CDo_avg() + VSPGeom().ComponentGroupList(c).CDi_avg(),
+                  VSPGeom().ComponentGroupList(c).CSo_avg() + VSPGeom().ComponentGroupList(c).CSi_avg(),                        
+                  VSPGeom().ComponentGroupList(c).CLo_avg(),
+                  VSPGeom().ComponentGroupList(c).CDo_avg(),   
+                  VSPGeom().ComponentGroupList(c).CSo_avg(),                           
+                  VSPGeom().ComponentGroupList(c).CLi_avg(),                  
+                  VSPGeom().ComponentGroupList(c).CDi_avg(),
+                  VSPGeom().ComponentGroupList(c).CSi_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwx_avg() + VSPGeom().ComponentGroupList(c).CFox_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwy_avg() + VSPGeom().ComponentGroupList(c).CFoy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwz_avg() + VSPGeom().ComponentGroupList(c).CFoz_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwx_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwy_avg(),
+                  VSPGeom().ComponentGroupList(c).CFiwz_avg(),                        
+                  VSPGeom().ComponentGroupList(c).CLiw_avg() + VSPGeom().ComponentGroupList(c).CLo_avg(),
+                  VSPGeom().ComponentGroupList(c).CDiw_avg() + VSPGeom().ComponentGroupList(c).CDo_avg(),
+                  VSPGeom().ComponentGroupList(c).CSiw_avg() + VSPGeom().ComponentGroupList(c).CSo_avg(),
+                  VSPGeom().ComponentGroupList(c).CLiw_avg(),                  
+                  VSPGeom().ComponentGroupList(c).CDiw_avg(),
+                  VSPGeom().ComponentGroupList(c).CSiw_avg());
+
+             }                            
                      
           }    
                                                         

--- a/src/vsp_aero/Solver/VSP_Solver.C
+++ b/src/vsp_aero/Solver/VSP_Solver.C
@@ -30020,13 +30020,19 @@ void VSP_SOLVER::IntegrateForcesAndMoments(void)
              DeltaFzo = DeltaDrag * FreeStreamVelocity_[2] / Vinf_;
              
              CFox_ += DeltaFxo;
-             CFox_ += DeltaFyo;
-             CFoy_ += DeltaFzo;
+             CFoy_ += DeltaFyo;
+             CFoz_ += DeltaFzo;
              
              VSPGeom().ComponentGroupList(c).CFox() += DeltaFxo;
              VSPGeom().ComponentGroupList(c).CFoy() += DeltaFyo;
              VSPGeom().ComponentGroupList(c).CFoz() += DeltaFzo;
-             
+
+             if ( TimeAccurate_ ) {
+                 VSPGeom().ComponentGroupList(c).CFox(Time_) += DeltaFxo;
+                 VSPGeom().ComponentGroupList(c).CFoy(Time_) += DeltaFyo;
+                 VSPGeom().ComponentGroupList(c).CFoz(Time_) += DeltaFzo;
+             }
+
           }
           
        }  

--- a/src/vsp_aero/Solver/WOPWOP.C
+++ b/src/vsp_aero/Solver/WOPWOP.C
@@ -593,7 +593,18 @@ void VSP_SOLVER::WriteOutSteadyStateNoiseFiles(int Case)
 
                             //1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890    
        fprintf(GroupFile_[c],"Force Coefficients for group %d --> %s \n\n",c,ComponentGroupList_[c].GroupName()); 
-       fprintf(GroupFile_[c],"   Time        Cx         Cy         Cz        Cxo        Cyo        Czo        Cxi        Cyi        Czi        Cmx        Cmy        Cmz        Cmxo       Cmyo       Cmzo       Cmxi       Cmyi       Cmzi        CL         CD         CS        CLo        CDo        CLi        CDi \n");
+       
+       if ( ComponentGroupList_[c].GeometryIsDynamic() == FULL_DYNAMIC ) {
+
+          fprintf(GroupFile_[c],"   Time          X          Y          Z        Pitch       Roll        Yaw         Cx         Cy         Cz        Cxo        Cyo        Czo        Cxi        Cyi        Czi        Cmx        Cmy        Cmz        Cmxo       Cmyo       Cmzo       Cmxi       Cmyi       Cmzi        CL         CD         CS        CLo        CDo        CLi        CDi \n");
+
+       }
+
+       else {
+
+          fprintf(GroupFile_[c],"   Time        Cx         Cy         Cz        Cxo        Cyo        Czo        Cxi        Cyi        Czi        Cmx        Cmy        Cmz        Cmxo       Cmyo       Cmzo       Cmxi       Cmyi       Cmzi        CL         CD         CS        CLo        CDo        CLi        CDi \n");
+
+       }
                           
        // Create rotor file
        
@@ -910,7 +921,18 @@ void VSP_SOLVER::WriteOutTimeAccurateNoiseFiles(int Case)
 
                             //1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890  
        fprintf(GroupFile_[c],"Force Coefficients for group %d --> %s \n\n",c,ComponentGroupList_[c].GroupName()); 
-       fprintf(GroupFile_[c],"   Time        Cx         Cy         Cz        Cxo        Cyo        Czo        Cxi        Cyi        Czi        Cmx        Cmy        Cmz        Cmxo       Cmyo       Cmzo       Cmxi       Cmyi       Cmzi        CL         CD        CLo        CDo        CLi        CDi \n");
+       
+       if ( ComponentGroupList_[c].GeometryIsDynamic() == FULL_DYNAMIC ) {
+
+          fprintf(GroupFile_[c],"   Time          X          Y          Z        Pitch       Roll        Yaw         Cx         Cy         Cz        Cxo        Cyo        Czo        Cxi        Cyi        Czi        Cmx        Cmy        Cmz        Cmxo       Cmyo       Cmzo       Cmxi       Cmyi       Cmzi        CL         CD        CLo        CDo        CLi        CDi \n");
+
+       }
+
+       else {
+
+          fprintf(GroupFile_[c],"   Time        Cx         Cy         Cz        Cxo        Cyo        Czo        Cxi        Cyi        Czi        Cmx        Cmy        Cmz        Cmxo       Cmyo       Cmzo       Cmxi       Cmyi       Cmzi        CL         CD        CLo        CDo        CLi        CDi \n");
+
+       }
                           
        // Create rotor file
        


### PR DESCRIPTION
1. Real bug fix (critical) (modified on lines 30023 & 30024)
-CFox_ += DeltaFyo;
-CFoy_ += DeltaFzo;

+CFoy_ += DeltaFyo;
+CFoz_ += DeltaFzo;

This is the only real wrong-assignment bug. DeltaFyo was accumulating in CFox_ and DeltaFzo in CFoy_. This causes lateral and vertical drag to be applied to the wrong component.


2. Fix for force accumulation in unsteady analysis (added on line 30029)

if (TimeAccurate_) {
    VSPGeom().ComponentGroupList(c).CFox(Time_) += DeltaFxo;
    VSPGeom().ComponentGroupList(c).CFoy(Time_) += DeltaFyo;
    VSPGeom().ComponentGroupList(c).CFoz(Time_) += DeltaFzo;
}

Without this, UpdateDynamicSystem does not receive the DeltaFlatPlateDrag in the time steps it uses to calculate aerodynamic forces.