### PR TITLE
Repair the Swept_Wing_API tutorial for VSPAERO 7.x

### DIFF
--- a/examples/vspaero_ex/Swept_Wing_API/README.md
+++ b/examples/vspaero_ex/Swept_Wing_API/README.md
@@ -74,7 +74,7 @@ Here are the steps to construct the wing in the OpenVSP GUI:
     <img height="380" src="Images/GUI_VSPAERO_Overview.png"> <img height="380" src="Images/GUI_VSPAERO_Advanced.png"> 
     </p>  
 
-    1. In *Overview*, ensure **Vortex Lattice (VLM)** is selected and the reference area, **Sref** is **2121.68**, reference span, **bref** is **127.26** and reference chord, **cref** is **16.672**. **Sref** is used while computing force and moment coefficients and **bref** and **cref** are used while computing moment coefficients. The area and the chord we input are based on the mean aerodynamic chord since, for the current geometry, results are available based on these parameters.
+    1. In *Overview*, ensure **Vortex Lattice (VLM)** is selected and the reference area, **Sref** is **2024.35**, reference span, **bref** is **127.26** and reference chord, **cref** is **16.672**. **Sref** is used while computing force and moment coefficients and **bref** and **cref** are used while computing moment coefficients. The area and the chord we input are based on the mean aerodynamic chord since, for the current geometry, results are available based on these parameters.
 
     2. We shall perform our sweep analysis for angle of attack in the range 0 to 9 degrees using an increment of 1 degree. Ensure in *Flow Condition*, **Alpha Start** is **0.0** degrees and **Alpha End** is **9.0** degrees with **Npts** set to **10**.
 
@@ -195,10 +195,7 @@ At any point, the `Print()` function may be used to print messages or variables 
    // PrintAnalysisInputs(myAnalysis);
    
    // Set inputs for VSPAero
-   array<int> analysis_method(1, VORTEX_LATTICE);
-   SetIntAnalysisInput(myAnalysis, "AnalysisMethod", analysis_method);
-   
-   array<double> Sref(1, 2121.68);
+   array<double> Sref(1, 2024.35);
    SetDoubleAnalysisInput(myAnalysis, "Sref", Sref);
    
    array<double> bref(1, 127.26);
@@ -242,7 +239,7 @@ At any point, the `Print()` function may be used to print messages or variables 
      array<double> alpha_vec = GetDoubleResults(sweepResults[i], "Alpha");
      Alpha_res[i] = alpha_vec[int(alpha_vec.length()) - 1];
    
-     array<double> cl_vec = GetDoubleResults(sweepResults[i], "CL");
+     array<double> cl_vec = GetDoubleResults(sweepResults[i], "CLtot");
      CL_res[i] = cl_vec[int(cl_vec.length()) - 1];
    
      Print(Alpha_res[i] + "      |   " + CL_res[i]);

--- a/examples/vspaero_ex/Swept_Wing_API/TR1208.vspscript
+++ b/examples/vspaero_ex/Swept_Wing_API/TR1208.vspscript
@@ -14,7 +14,7 @@ void main()
   SetParmVal(myWing, "SectTess_U", "XSec_1", 20);
   SetParmVal(myWing, "Span", "XSec_1", 63.63);
   SetParmVal(myWing, "Taper", "XSec_1", 0.45);
-  SetParmVal(myWing, "Root_Chord", "XSec_1", 16.672);
+  SetParmVal(myWing, "Root_Chord", "XSec_1", 21.941);
   SetParmVal(myWing, "Sweep", "XSec_1", 45.0);
   SetParmVal(myWing, "Sweep_Location", "XSec_1", 0.25);
   Update();
@@ -48,10 +48,7 @@ void main()
   // PrintAnalysisInputs(myAnalysis);
 
   // Set inputs for VSPAero
-  array<int> analysis_method(1, VORTEX_LATTICE);
-  SetIntAnalysisInput(myAnalysis, "AnalysisMethod", analysis_method);
-
-  array<double> Sref(1, 2121.68);
+  array<double> Sref(1, 2024.35);
   SetDoubleAnalysisInput(myAnalysis, "Sref", Sref);
 
   array<double> bref(1, 127.26);
@@ -87,7 +84,7 @@ void main()
     array<double> alpha_vec = GetDoubleResults(sweepResults[i], "Alpha");
     Alpha_res[i] = alpha_vec[int(alpha_vec.length()) - 1];
 
-    array<double> cl_vec = GetDoubleResults(sweepResults[i], "CL");
+    array<double> cl_vec = GetDoubleResults(sweepResults[i], "CLtot");
     CL_res[i] = cl_vec[int(cl_vec.length()) - 1];
 
     Print(Alpha_res[i] + "      |   " + CL_res[i]);


### PR DESCRIPTION
The `examples/vspaero_ex/Swept_Wing_API` tutorial no longer runs. The script has not been touched since 1af7d0df (Dec 2020) and predates the VSPAERO 7.x solver. Reproduced with the official 3.51.2 macOS ARM64 release, running the shipped example against the shipped binary:

```
$ vspscript -script TR1208.vspscript
ReadExecute (51, 33) : ERR  : No matching symbol 'VORTEX_LATTICE'
Error ExecuteScript GetModule
```

Four separate defects, each verified individually.

### 1. `AnalysisMethod` / `VORTEX_LATTICE` no longer exist

The script fails to compile at this line. VSPAERO 7.x replaced the analysis-method switch with separate thin and thick geometry sets (`ThinGeomSet` defaults to `SET_SHOWN`, `GeomSet` to `SET_NONE`), so a lone wing is already solved as a vortex lattice. The two lines are simply removed.

### 2. `Root_Chord` is set to the MAC, not the root chord

The script sets `Root_Chord` to `16.672`, but that is the mean aerodynamic chord. The README table in this same directory gives the root chord as **21.941 in**. The resulting planform is wrong:

| `Root_Chord` | area | aspect ratio | MAC |
|---|---|---|---|
| 16.672 (current) | 1538.22 | 10.528 | 12.667 |
| 21.941 (fixed) | 2024.35 | **8.000** | **16.670** |

TR-1208 specifies aspect ratio 8.02 and MAC 16.672, so 21.941 is the value that reproduces the report.

### 3. `Sref` does not match the geometry

`Sref` is `2121.68`, which is `bref × cref` = 127.26 × 16.672 — span times MAC, not an area. The planform the corrected script builds has an area of 2024.35. Since `Sref` normalises every force coefficient, this alone shifts CL by ~5%.

### 4. `CL` was renamed to `CLtot`

`GetDoubleResults(sweepResults[i], "CL")` no longer resolves, so even after fixing 1–3 the tutorial prints zeros:

```
Error Code: 5, Desc: GetDoubleResults::Can't Find Name CL at index 0
 0      |   0
 1      |   0
```

The history results expose `CLtot`, `CLi`, `CLo`, `CLwtot`, `CLiw`. The loop's indexing into `ResultsVec` is still correct — the first `nAlpha` entries are the `VSPAERO_History` results in alpha order.

## Result

With all four applied the tutorial runs without a single error and reproduces the validation case it is meant to teach:

```
 ALPHA  |  CL
 ------ | ------
 0      |   0
 3      |   0.197148
 6      |   0.395915
 9      |   0.591921
```

CL is linear in alpha at **0.0658 /deg**, against a DATCOM estimate of **0.0651 /deg** for aspect ratio 8.02 at 45° sweep — under 1% apart. Before this change the same script produced 0.0372 /deg, off by 43%.

## Not addressed

The GUI walkthrough still tells the reader to select **Vortex Lattice (VLM)** in the *VSPAERO Overview* tab, and the accompanying screenshots predate the current dialog. I have not touched that text because I cannot verify the present GUI layout; a maintainer should confirm what replaced that control. The `Sref` figure in the GUI section is updated to stay consistent with the script.

Tested on macOS 15.2 ARM64 with the OpenVSP 3.51.2 release build (VSPAERO 7.2.2).
