### PR TITLE
Fix Edit Curve pan gestureFix Edit Curve pan gesture

### DIFF
--- a/src/gui_and_draw/MainGLWindow.cpp
+++ b/src/gui_and_draw/MainGLWindow.cpp
@@ -3122,7 +3122,7 @@ int EditXSecWindow::handle( int fl_event )
     }
 
 
-    if ( fl_event == FL_PUSH && !Fl::event_button2() )
+    if ( fl_event == FL_PUSH && Fl::event_button1() )
     {
         vec3d coord = PixelToCoord( m_mouse_x, m_mouse_y );
 
@@ -3183,7 +3183,7 @@ int EditXSecWindow::handle( int fl_event )
             curve_editor->UpdateIndexSelector( new_pnt );
         }
     }
-    else if ( fl_event == FL_DRAG && m_LastHit != -1 && !Fl::event_button2() )
+    else if ( fl_event == FL_DRAG && m_LastHit != -1 && Fl::event_button1() )
     {
         vec3d coord = PixelToCoord( m_mouse_x, m_mouse_y );
 


### PR DESCRIPTION
The Edit Curve window's specialized event handler previously processed
all mouse buttons except the middle button. This allowed right-button
events, which are used by the generic viewport for panning, to enter the
curve point-selection and dragging logic.

Restrict curve-specific selection and point dragging to the left mouse
button. This leaves middle-button zooming and right-button panning to the
existing VspGlWindow behavior.

The change is limited to the EditXSecWindow event handler